### PR TITLE
feat: action to set USK state after transition

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -70,6 +70,14 @@ export function AtemTransitionSelectionPickers(model: ModelSpec): CompanionInput
 
   return pickers
 }
+export function AtemOnAirPicker(): CompanionInputFieldCheckbox {
+  return {
+    type: 'checkbox',
+    id: 'onair',
+    label: 'On Air',
+    default: true
+  }
+}
 export function AtemMEPicker(model: ModelSpec, id: number): CompanionInputFieldDropdown {
   return {
     id: `mixeffect${id ? id : ''}`,


### PR DESCRIPTION
This adds an action to set USK state after transition; this allows (in combination with "AUTO transition operation") using transitions with a specific USK state instead of only the toggle behavior that is previously present.

AFAICT this is impossible to do with macros or with existing actions because there's no ATEM command for "put this in the next transition only if the state is different".