### PR TITLE
feat: add support to toggle upstream keys in preview

### DIFF
--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -31,7 +31,8 @@ import {
   AtemSuperSourcePropertiesPickers,
   AtemTransitionSelectionPickers,
   AtemTransitionStylePicker,
-  AtemUSKPicker
+  AtemUSKPicker,
+  AtemTransitionSelectionMatchMethod
 } from './input'
 import { ModelSpec } from './models'
 import { getDSK, getME, getMultiviewerWindow, getSuperSourceBox, getUSK, TallyBySource } from './state'
@@ -459,12 +460,18 @@ function transitionFeedbacks(instance: InstanceSkel<AtemConfig>, model: ModelSpe
         ForegroundPicker(instance.rgb(0, 0, 0)),
         BackgroundPicker(instance.rgb(255, 255, 0)),
         AtemMEPicker(model, 0),
-        ...AtemTransitionSelectionPickers(model)
+        ...AtemTransitionSelectionPickers(model),
+        AtemTransitionSelectionMatchMethod()
       ],
       callback: (evt: CompanionFeedbackEvent): CompanionFeedbackResult => {
         const me = getME(state, evt.options.mixeffect)
         const expectedSelection = calculateTransitionSelection(model.USKs, evt.options)
-        if (me && me.transitionProperties.selection === expectedSelection) {
+        if (!me) {
+          return {}
+        }
+        if (evt.options.matchmethod === '1' && (me.transitionProperties.selection & expectedSelection) === expectedSelection) {
+          return getOptColors(evt)
+        } else if (evt.options.matchmethod != '1' && me.transitionProperties.selection === expectedSelection) {
           return getOptColors(evt)
         }
         return {}

--- a/src/input.ts
+++ b/src/input.ts
@@ -70,6 +70,22 @@ export function AtemTransitionSelectionPickers(model: ModelSpec): CompanionInput
 
   return pickers
 }
+export function AtemTransitionSelectionMatchMethod(): CompanionInputFieldDropdown {
+  return {
+    id: 'matchmethod',
+    label: 'Match method',
+    type: 'dropdown',
+    default: '0',
+    choices: [{
+      id: '0',
+      label: 'Exact'
+    },
+    {
+      id: '1',
+      label: 'At least'
+    }]
+  }
+}
 export function AtemMEPicker(model: ModelSpec, id: number): CompanionInputFieldDropdown {
   return {
     id: `mixeffect${id ? id : ''}`,

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -285,8 +285,8 @@ export function GetPresetsList(
   for (let me = 0; me < model.MEs; ++me) {
     for (let key = 0; key < model.USKs; ++key) {
       presets.push({
-        category: 'KEYs',
-        label: `Toggle upstream M/E ${me + 1} KEY ${key + 1}`,
+        category: 'KEYs OnAir',
+        label: `Toggle upstream M/E ${me + 1} KEY ${key + 1} OnAir`,
         bank: {
           style: 'text',
           text: 'KEY ' + (key + 1),
@@ -310,6 +310,40 @@ export function GetPresetsList(
             action: ActionId.USKOnAir,
             options: {
               onair: 'toggle',
+              key,
+              mixeffect: me
+            }
+          }
+        ]
+      })
+
+      presets.push({
+        category: 'KEYs',
+        label: `Toggle upstream M/E ${me + 1} KEY ${key + 1}`,
+        bank: {
+          style: 'text',
+          text: 'KEY ' + (key + 1),
+          size: '24',
+          color: instance.rgb(255, 255, 255),
+          bgcolor: instance.rgb(0, 0, 0)
+        },
+        feedbacks: [
+          {
+            type: FeedbackId.TransitionSelection,
+            options: {
+              bg: instance.rgb(255, 255, 0),
+              fg: instance.rgb(255, 255, 255),
+              ['key' + key]: true,
+              mixeffect: me,
+              matchmethod: '1',
+              background: false
+            }
+          }
+        ],
+        actions: [
+          {
+            action: ActionId.USKToggle,
+            options: {
               key,
               mixeffect: me
             }
@@ -359,7 +393,7 @@ export function GetPresetsList(
   // Downstream keyers
   for (let dsk = 0; dsk < model.DSKs; ++dsk) {
     presets.push({
-      category: 'KEYs',
+      category: 'KEYs OnAir',
       label: `Toggle downstream KEY ${dsk + 1}`,
       bank: {
         style: 'text',

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,6 +1,6 @@
 import { AtemState, Commands } from 'atem-connection'
 import { InputValue } from '../../../instance_skel_types'
-import { SuperSourceBox } from 'atem-connection/dist/state/video'
+import { SuperSourceBox, TransitionProperties } from 'atem-connection/dist/state/video'
 import { MultiViewerWindowState } from 'atem-connection/dist/state/settings'
 
 // TODO - these should be exported more cleanly from atem-connection
@@ -20,6 +20,13 @@ export function getUSK(
 ): UpstreamKeyer | undefined {
   const me = getME(state, meIndex)
   return me ? me.upstreamKeyers[Number(keyIndex)] : undefined
+}
+export function getTransitionProperties(
+  state: AtemState,
+  meIndex: InputValue | undefined
+): TransitionProperties | undefined {
+  const me = getME(state, meIndex)
+  return me ? me.transitionProperties : undefined
 }
 export function getDSK(state: AtemState, keyIndex: InputValue | undefined): DownstreamKeyer | undefined {
   return state.video.downstreamKeyers[Number(keyIndex)]


### PR DESCRIPTION
I was looking for a way to mimick the behavior of the USK Key buttons of the ATEM.
Therefor I added a new action `USKToggle`, this toggles the value of the selected USK.

Also to support the feedback I added the option to use the existing TransitionSelection with another method of matching.

I renamed the existing preset category `KEYs` to `KEYs OnAir`. The new presets have the category `KEYs`.

This is my first contribution to this project, I hope I followed the guidelines correctly