### PR TITLE
fix: learning for DSK rate

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -637,10 +637,10 @@ function dskActions(instance: InstanceSkel<AtemConfig>, atem: Atem | undefined, 
 					learn: (feedback) => {
 						const dsk = getDSK(state, feedback.options.key)
 
-						if (dsk?.sources) {
+						if (dsk?.properties) {
 							return {
 								...feedback.options,
-								rate: dsk.sources.rate,
+								rate: dsk.properties.rate,
 							}
 						} else {
 							return undefined


### PR DESCRIPTION
When I did the initial commit for DSK rate, I had only tested against the `master` branch of companion and not `beta`. After doing some other work, I realized I had not tested the learn part of rate since that's not currently on `master`. 

This time, I switched to `beta` and watched the changes live in ATEM software control. 🤦 