### PR TITLE
fix: wrong number of auxes for sdi-extreme-iso

### DIFF
--- a/src/models/sdiextremeiso.ts
+++ b/src/models/sdiextremeiso.ts
@@ -226,7 +226,7 @@ export const ModelSpecSDIExtremeISO: ModelSpec = {
 			meAvailability: Enums.MeAvailability.None,
 		},
 	],
-	auxes: 2,
+	auxes: 4,
 	MEs: 1,
 	USKs: 4,
 	DSKs: 2,


### PR DESCRIPTION
ATEM SDI Extreme ISO has 4 auxiliary outputs instead of 2 which was present in HDMI version of Extreme ISO model.