### PR TITLE
Implement an action that can arbitrarily alter the presence of every component in the next selection

### DIFF
--- a/src/choices.ts
+++ b/src/choices.ts
@@ -23,6 +23,38 @@ export const CHOICES_ON_OFF_TOGGLE: DropdownChoice[] = [
 	{ id: 'toggle', label: 'Toggle' },
 ]
 
+export enum NextTransBackgroundChoices {
+	NoChange = 'no-change',
+	Include = 'include',
+	Omit = 'omit',
+	Toggle = 'toggle',
+}
+
+export const CHOICES_NEXTTRANS_BACKGROUND: DropdownChoice[] = [
+	{ id: NextTransBackgroundChoices.NoChange, label: 'No change' },
+	{ id: NextTransBackgroundChoices.Include, label: 'Include' },
+	{ id: NextTransBackgroundChoices.Omit, label: 'Omit' },
+	{ id: NextTransBackgroundChoices.Toggle, label: 'Toggle' },
+]
+
+export enum NextTransKeyChoices {
+	NoChange = 'no-change',
+	On = 'on',
+	Off = 'off',
+	Toggle = 'toggle',
+	Include = 'include',
+	Omit = 'omit',
+}
+
+export const CHOICES_NEXTTRANS_KEY: DropdownChoice[] = [
+	{ id: NextTransKeyChoices.NoChange, label: 'No change' },
+	{ id: NextTransKeyChoices.On, label: 'On' },
+	{ id: NextTransKeyChoices.Off, label: 'Off' },
+	{ id: NextTransKeyChoices.Toggle, label: 'Toggle' },
+	{ id: NextTransKeyChoices.Include, label: 'Include' },
+	{ id: NextTransKeyChoices.Omit, label: 'Omit' },
+]
+
 export const CHOICES_KEYTRANS: DropdownChoice[] = [
 	{ id: 'true', label: 'On Air' },
 	{ id: 'false', label: 'Off' },

--- a/src/input.ts
+++ b/src/input.ts
@@ -10,6 +10,8 @@ import {
 	CHOICES_KEYTRANS,
 	CHOICES_SSRCBOXES,
 	CHOICES_BORDER_BEVEL,
+	CHOICES_NEXTTRANS_BACKGROUND,
+	CHOICES_NEXTTRANS_KEY,
 	GetAudioInputsList,
 	GetAuxIdChoices,
 	GetDSKIdChoices,
@@ -20,6 +22,8 @@ import {
 	GetSuperSourceIdChoices,
 	GetTransitionStyleChoices,
 	GetUSKIdChoices,
+	NextTransBackgroundChoices,
+	NextTransKeyChoices,
 	SourcesToChoices,
 } from './choices.js'
 import type { ModelSpec } from './models/index.js'
@@ -53,6 +57,29 @@ export function AtemRatePicker(label: string): CompanionInputFieldNumber {
 		range: true,
 		default: 25,
 	}
+}
+export function AtemTransitionSelectComponentsPickers(model: ModelSpec): CompanionInputFieldDropdown[] {
+	const pickers: CompanionInputFieldDropdown[] = [
+		{
+			type: 'dropdown',
+			id: 'background',
+			label: 'Background',
+			choices: CHOICES_NEXTTRANS_BACKGROUND,
+			default: NextTransBackgroundChoices.NoChange,
+		},
+	]
+
+	for (let i = 0; i < model.USKs; i++) {
+		pickers.push({
+			label: `Key ${i + 1}`,
+			type: 'dropdown',
+			id: `key${i}`,
+			choices: CHOICES_NEXTTRANS_KEY,
+			default: NextTransKeyChoices.NoChange,
+		})
+	}
+
+	return pickers
 }
 export function AtemTransitionSelectionPickers(model: ModelSpec): CompanionInputFieldCheckbox[] {
 	const pickers: CompanionInputFieldCheckbox[] = [


### PR DESCRIPTION
### Use case

I want to program three buttons to move among three possible preview states (then using a final AUTO transition to put them in program) -- from any state to any other state.

1. Input 4 as background, no key onAir
2. Input 1 as background, no key onAir
3. Input 4 as background, key onAir

### Problem

3->1 and 2->1 transitions start from different key onAir states, so merely setting or unsetting the key in next transition can't produce the desired behavior in every case.

Two existing actions to support this fall short: "Transition: Change selection component" and "Transition: Change selection" can choose whether the key status is changed in the next transition.  But there's no way to condition this based on the present onAir state.  So there's no way to guarantee the final state (displayed/hidden) of the key in preview.

### Proposed new action

I propose a "Transition: Select components in transition" action, applying to all components at once (avoiding races and eliminating the need for batching), that supports turning on/off a component in preview or syncing with/against the component's current onAir status.

This action offers a dropdown of options for background and for every upstream key.  Because onAir only applies to keys, the dropdown for the background and the dropdown for each key have slightly different options.

![background-dropdown](https://github.com/bitfocus/companion-module-bmd-atem/assets/4139753/e8258c80-e35a-4b7f-adb2-325cb263ca2d)

* "No change" leaves the component's status unaltered.
* "Include" includes the preview-input background in the next transition.
    * This is what checking the "Transition: Change selection" background checkbox does.
* "Omit" unapplies the preview-input background from preview, so the next transition will leave the background unchanged.
    * This is what unchecking the "Transition: Change selection" background checkbox does.
* "Toggle" flips the preview-input background from being included in the next transition to not, or vice versa.
    * This is what "Transition: Change selection component" with "Toggle" selected does.

[Screencast from 2023-09-27 18-25-02.webm](https://github.com/bitfocus/companion-module-bmd-atem/assets/4139753/6e59b646-bde6-4410-ba10-8bb5bb864e52)

* "No change" leaves the component's status unaltered.
* "On" puts the key into the preview, to be displayed after next transition.
    * This is a new operation.
* "Off" removes the key from the preview, so it won't be displayed after next transition.
    * This is a new operation.
* "Toggle" inverts the presence/absence of the key in preview.
    * This is what "Transition: Change selection component" with "Toggle" selected does.
* "Include" selects the key for transition (on to off, or off to on).
    * This is what checking the "Transition: Change selection" background checkbox does (or "Transition: Change selection component" with "On Air").
* "Omit" unselects the key for transition (so the transition won't affect visibility or not of the key on transition).
    * This is what unchecking the "Transition: Change selection" background checkbox does (or "Transition: Change selection component" with "Off").
* "Copy OnAir state" puts the key in preview if it's onAir in program, removes it from preview otherwise.
    * This is a new operation.
* "Invert OnAir state" *removes* the key in preview if it's onAir in program, puts the key in preview otherwise.
    * This is a new operation.

### Related issues

This issue isn't quite a duplicate of part of #223.  The initial request there was only for a DSK, not a USK, with USK support mooted only as part of a proposed comprehensive fix.  (I only have access to an ATEM Mini Pro, so my ability to test anything for DSKs and USKs simultaneously is limited.  It should be easy to extend this to DSKs if desired.)

Parts of this are a high-level version of the low-level action requested in https://github.com/nrkno/sofie-atem-connection/issues/113.  I don't know that there's any way _in actions_ to query onAir state right now to replicate the supplied answer there, tho.

### Uncertain points

Naming is, as always, debatable.  I made semi-arbitrary choices here.  Feel free to offer better names/descriptions if you have them.

Per the rationale for non-batching as discussed on Slack, I made this a non-batching operation.

The end result of this action might potentially be to remove every single component from the next transition.  ATEM Software Control doesn't allow this: if you try to unselect the last selected component, nothing will happen.  This patch simply leaves all components unchanged if the result would be to unselect every component.  Is that something a user might expect?  I don't see an intuitive behavior here (at least with my fairly-novice intuitions about switching).

I didn't test this with multiple keys, because ATEM Mini Pro.  I'm relatively sure the logic works with multiple keys, but someone really should verify that!

### Conclusion

There are some open design-space questions here (and maybe some I couldn't identify).  I supplied answers I think make sense.  I'm happy to implement different answers that are obvious to someone with more experience in this space.  Just let me know what you want.  :-)