### PR TITLE
feat(camera_control): Add continuous zoom support

### DIFF
--- a/src/actions/ActionId.ts
+++ b/src/actions/ActionId.ts
@@ -102,6 +102,7 @@ export enum ActionId {
 	CameraControlIncrementLensIris = 'cameraControlIncrementLensIris',
 	CameraControlLensAutoIris = 'cameraControlLensAutoIris',
 	CameraControlLensOpticalImageStabilisation = 'cameraControlLensOpticalImageStabilisation',
+	CameraControlLensZoom = 'cameraControlLensZoom',
 
 	CameraControlVideoManualWhiteBalance = 'cameraControlVideoManualWhiteBalance',
 	CameraControlVideoIncrementManualWhiteBalance = 'cameraControlVideoIncrementManualWhiteBalance',

--- a/src/actions/cameraControl/lens.ts
+++ b/src/actions/cameraControl/lens.ts
@@ -31,6 +31,10 @@ export interface AtemCameraControlLensActions {
 		cameraId: string
 		state: TrueFalseToggle
 	}
+	[ActionId.CameraControlLensZoom]: {
+		cameraId: string
+		delta: string
+	}
 }
 
 export function createCameraControlLensActions(
@@ -46,6 +50,7 @@ export function createCameraControlLensActions(
 			[ActionId.CameraControlIncrementLensIris]: undefined,
 			[ActionId.CameraControlLensAutoIris]: undefined,
 			[ActionId.CameraControlLensOpticalImageStabilisation]: undefined,
+			[ActionId.CameraControlLensZoom]: undefined,
 		}
 	}
 
@@ -193,6 +198,29 @@ export function createCameraControlLensActions(
 				}
 
 				await commandSender?.lensEnableOpticalImageStabilisation(cameraId, target)
+			},
+		},
+
+		[ActionId.CameraControlLensZoom]: {
+			name: 'Camera Control: Zoom (Continuous)',
+			options: {
+				cameraId: CameraControlSourcePicker(),
+				delta: {
+					id: 'delta',
+					type: 'textinput',
+					label: 'Delta',
+					default: '0.1',
+					tooltip: 'Max range -1.0 - 1.0',
+					useVariables: true,
+				},
+			},
+			callback: async ({ options }) => {
+				const cameraId = await options.getParsedNumber('cameraId')
+				const value = await options.getParsedNumber('delta')
+				await commandSender?.lensSetContinuousZoomSpeed(cameraId, value)
+				setTimeout(() => {
+					void commandSender?.lensSetContinuousZoomSpeed(cameraId, 0)
+				}, 50)
 			},
 		},
 	}

--- a/src/actions/cameraControl/lens.ts
+++ b/src/actions/cameraControl/lens.ts
@@ -33,7 +33,7 @@ export interface AtemCameraControlLensActions {
 	}
 	[ActionId.CameraControlLensZoom]: {
 		cameraId: string
-		delta: string
+		zoom: string
 	}
 }
 
@@ -205,22 +205,19 @@ export function createCameraControlLensActions(
 			name: 'Camera Control: Zoom (Continuous)',
 			options: {
 				cameraId: CameraControlSourcePicker(),
-				delta: {
-					id: 'delta',
+				zoom: {
+					id: 'zoom',
 					type: 'textinput',
-					label: 'Delta',
-					default: '0.1',
+					label: 'Zoom speed',
+					default: '0.0',
 					tooltip: 'Max range -1.0 - 1.0',
 					useVariables: true,
 				},
 			},
 			callback: async ({ options }) => {
 				const cameraId = await options.getParsedNumber('cameraId')
-				const value = await options.getParsedNumber('delta')
+				const value = await options.getParsedNumber('zoom')
 				await commandSender?.lensSetContinuousZoomSpeed(cameraId, value)
-				setTimeout(() => {
-					void commandSender?.lensSetContinuousZoomSpeed(cameraId, 0)
-				}, 50)
 			},
 		},
 	}


### PR DESCRIPTION
Related to #288

I'm not found of the `setTimeout` in the code. But it doesn't look like the ATEM support a relative input. So this is a hack to make it work.

If there is a better way I would love implementing it.

Note: This requires https://github.com/Julusian/atem-connection-camera-control/pull/3 to be merged and released first.