### PR TITLE
patch for #343 fixes regex typo for ROUTING_STRING_REGEX and add testcase

### DIFF
--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -50,4 +50,10 @@ test('parseAudioRoutingStringSingle', () => {
 
 	const parse5 = parseAudioRoutingStringSingle('9291-8_9')
 	expect(parse5).toEqual(null)
+	
+	const parse6 = parseAudioRoutingStringSingle('2001-9_10')
+	expect(parse6).toEqual(combineInputId(2001, AudioChannelPair.Channel9_10))
+
+	const parse7 = parseAudioRoutingStringSingle('2001-15_16')
+	expect(parse7).toEqual(combineInputId(2001, AudioChannelPair.Channel15_16))
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -122,7 +122,7 @@ export function parseAudioRoutingString(ids: string): number[] {
 		.filter((id): id is number => id !== null)
 }
 
-const ROUTING_STRING_REGEX = /(\d+)-([\d]+_[\d+])/i
+const ROUTING_STRING_REGEX = /(\d+)-([\d]+_[\d]+)/i
 export function parseAudioRoutingStringSingle(id: string): number | null {
 	id = id.trim()
 	if (!id) return null


### PR DESCRIPTION
in [companion-module-bmd-atem/src/util.ts](https://github.com/bitfocus/companion-module-bmd-atem/blob/main/src/util.ts):125
```diff
- const ROUTING_STRING_REGEX = /(\d+)-([\d]+_[\d+])/i
+ const ROUTING_STRING_REGEX = /(\d+)-([\d]+_[\d]+)/i
```
**[\d+]** truncates the last digits, so that “2001-9_10” is interpreted as “2001-9_1”, so that the following code cannot be resolved to the correct pairValueOption. It should be **[\d]+**.

Added two testcases to for two digits channel's like 'Channel15_16'.