### PR TITLE
feat(display-clock): ✨ add ability to offset start time

### DIFF
--- a/src/actions/ActionId.ts
+++ b/src/actions/ActionId.ts
@@ -100,6 +100,7 @@ export enum ActionId {
 	DisplayClockState = 'displayClockState',
 	DisplayClockConfigure = 'displayClockConfigure',
 	DisplayClockStartTime = 'displayClockStartTime',
+	DisplayClockOffsetStartTime = 'displayClockOffsetStartTime',
 	Timecode = 'timecode',
 	TimecodeMode = 'timecodeMode',
 

--- a/src/actions/displayClock.ts
+++ b/src/actions/displayClock.ts
@@ -180,10 +180,11 @@ export function createDisplayClockActions(
 						displayClockConfig.startFrom.seconds
 				}
 
-				const newTime = currentTime + offset
+				let newTime = currentTime + offset
 
-				const maxTime = 23 * 3600 + 59 * 60 + 59
-				if (newTime < 0 || newTime > maxTime) return
+				const day = 24 * 3600
+				newTime = newTime % day
+				if (newTime < 0) newTime += day
 
 				const hours = Math.floor(newTime / 3600)
 				const minutes = Math.floor((newTime % 3600) / 60)

--- a/src/actions/displayClock.ts
+++ b/src/actions/displayClock.ts
@@ -163,37 +163,24 @@ export function createDisplayClockActions(
 			name: 'Display Clock: Offset Start Time',
 			options: { ...AtemDisplayClockTimeOffsetPickers() },
 			callback: async ({ options }) => {
-				const hourOffset = options.getPlainNumber('hours')
-				const minuteOffset = options.getPlainNumber('minutes')
-				const secondOffset = options.getPlainNumber('seconds')
+				const clockState = state.state.displayClock?.properties?.startFrom
+				const currentTime = clockState ? clockState.hours * 3600 + clockState.minutes * 60 + clockState.seconds : 0
 
-				const offset = Number(hourOffset) * 3600 + Number(minuteOffset) * 60 + Number(secondOffset)
-
-				let currentTime = 0
-
-				const displayClockConfig = state.state.displayClock?.properties
-
-				if (displayClockConfig) {
-					currentTime =
-						displayClockConfig.startFrom.hours * 3600 +
-						displayClockConfig.startFrom.minutes * 60 +
-						displayClockConfig.startFrom.seconds
-				}
+				const offset =
+					options.getPlainNumber('hours') * 3600 +
+					options.getPlainNumber('minutes') * 60 +
+					options.getPlainNumber('seconds')
 
 				let newTime = currentTime + offset
 
-				const day = 24 * 3600
-				newTime = newTime % day
-				if (newTime < 0) newTime += day
-
-				const hours = Math.floor(newTime / 3600)
-				const minutes = Math.floor((newTime % 3600) / 60)
-				const seconds = newTime % 60
+				const oneDay = 24 * 3600
+				newTime = newTime % oneDay
+				if (newTime < 0) newTime += oneDay
 
 				const time: DisplayClock.DisplayClockTime = {
-					hours,
-					minutes,
-					seconds,
+					hours: Math.floor(newTime / 3600),
+					minutes: Math.floor((newTime % 3600) / 60),
+					seconds: newTime % 60,
 					frames: 0,
 				}
 

--- a/src/actions/displayClock.ts
+++ b/src/actions/displayClock.ts
@@ -180,9 +180,10 @@ export function createDisplayClockActions(
 						displayClockConfig.startFrom.seconds
 				}
 
-				let newTime = currentTime + offset
+				const newTime = currentTime + offset
 
-				if (newTime < 0) newTime = 0
+				const maxTime = 23 * 3600 + 59 * 60 + 59
+				if (newTime < 0 || newTime > maxTime) return
 
 				const hours = Math.floor(newTime / 3600)
 				const minutes = Math.floor((newTime % 3600) / 60)

--- a/src/actions/displayClock.ts
+++ b/src/actions/displayClock.ts
@@ -163,30 +163,30 @@ export function createDisplayClockActions(
 			name: 'Display Clock: Offset Start Time',
 			options: { ...AtemDisplayClockTimeOffsetPickers() },
 			callback: async ({ options }) => {
-				const hoursOffset = options.getPlainNumber('hours')
+				const hourOffset = options.getPlainNumber('hours')
 				const minuteOffset = options.getPlainNumber('minutes')
 				const secondOffset = options.getPlainNumber('seconds')
 
-				const timeOffsetInSeconds = hoursOffset * 3600 + minuteOffset * 60 + secondOffset
+				const offset = Number(hourOffset) * 3600 + Number(minuteOffset) * 60 + Number(secondOffset)
 
-				let currentTimeInSeconds = 0
+				let currentTime = 0
 
 				const displayClockConfig = state.state.displayClock?.properties
 
 				if (displayClockConfig) {
-					currentTimeInSeconds =
+					currentTime =
 						displayClockConfig.startFrom.hours * 3600 +
 						displayClockConfig.startFrom.minutes * 60 +
 						displayClockConfig.startFrom.seconds
 				}
 
-				let newTimeInSeconds = currentTimeInSeconds + timeOffsetInSeconds
+				let newTime = currentTime + offset
 
-				if (newTimeInSeconds < 0) newTimeInSeconds = 0
+				if (newTime < 0) newTime = 0
 
-				const hours = Math.floor(newTimeInSeconds / 3600)
-				const minutes = Math.floor((newTimeInSeconds % 3600) / 60)
-				const seconds = newTimeInSeconds % 60
+				const hours = Math.floor(newTime / 3600)
+				const minutes = Math.floor((newTime % 3600) / 60)
+				const seconds = newTime % 60
 
 				const time: DisplayClock.DisplayClockTime = {
 					hours,

--- a/src/input.ts
+++ b/src/input.ts
@@ -2043,6 +2043,45 @@ export function AtemDisplayClockTimePickers(): {
 	}
 }
 
+export function AtemDisplayClockTimeOffsetPickers(): {
+	hours: CompanionInputFieldNumber
+	minutes: CompanionInputFieldNumber
+	seconds: CompanionInputFieldNumber
+} {
+	return {
+		hours: {
+			type: 'number',
+			id: 'hours',
+			label: 'Hours',
+			min: -23,
+			max: 23,
+			range: true,
+			default: 0,
+			step: 1,
+		},
+		minutes: {
+			type: 'number',
+			id: 'minutes',
+			label: 'Minutes',
+			min: -59,
+			max: 59,
+			range: true,
+			default: 0,
+			step: 1,
+		},
+		seconds: {
+			type: 'number',
+			id: 'seconds',
+			label: 'Seconds',
+			min: -59,
+			max: 59,
+			range: true,
+			default: 0,
+			step: 1,
+		},
+	}
+}
+
 export function AtemFairlightAudioRoutingSourcePicker(model: ModelSpec, state: AtemState): CompanionInputFieldDropdown {
 	const sources = FairlightAudioRoutingSources(model, state)
 


### PR DESCRIPTION
As the title already tells this aims to add an action for offsetting the display clocks start time relative to its current state, so one can make buttons that add or subtract a fixed amount of time to / from the atem mixers build-in timer. I build this as I needed it for an event myself and thought I might as well share it with the community. 🙌

Thank you all for this great companion module! 🙏

Best regards
@lukas-runge