### PR TITLE
feat: Add media filename variable support

### DIFF
--- a/src/actions/mediaPlayer.ts
+++ b/src/actions/mediaPlayer.ts
@@ -111,22 +111,24 @@ export function createMediaPlayerActions(
 			callback: async ({ options }) => {
 				const [mediaplayer, slot] = await Promise.all([
 					options.getParsedNumber('mediaplayer'),
-					options.getParsedNumber('slot'),
+					options.getParsedString('slot'),
 				])
 
 				if (model.media.clips > 0 && options.getPlainBoolean('isClip')) {
+					const position = state.state.media.clipPool.findIndex((clip) => (clip?.name == slot ? true : false))
 					await atem?.setMediaPlayerSource(
 						{
 							sourceType: Enums.MediaSourceType.Clip,
-							clipIndex: slot - 1,
+							clipIndex: position != -1 ? position : parseInt(slot) - 1,
 						},
 						mediaplayer - 1,
 					)
 				} else {
+					const position = state.state.media.stillPool.findIndex((still) => (still?.fileName == slot ? true : false))
 					await atem?.setMediaPlayerSource(
 						{
 							sourceType: Enums.MediaSourceType.Still,
-							stillIndex: slot - 1,
+							stillIndex: position != -1 ? position : parseInt(slot) - 1,
 						},
 						mediaplayer - 1,
 					)

--- a/src/actions/mediaPlayer.ts
+++ b/src/actions/mediaPlayer.ts
@@ -115,7 +115,7 @@ export function createMediaPlayerActions(
 				])
 
 				if (model.media.clips > 0 && options.getPlainBoolean('isClip')) {
-					const position = state.state.media.clipPool.findIndex((clip) => (clip?.name == slot ? true : false))
+					const position = state.state.media.clipPool.findIndex((clip) => clip?.name == slot)
 					await atem?.setMediaPlayerSource(
 						{
 							sourceType: Enums.MediaSourceType.Clip,
@@ -124,7 +124,7 @@ export function createMediaPlayerActions(
 						mediaplayer - 1,
 					)
 				} else {
-					const position = state.state.media.stillPool.findIndex((still) => (still?.fileName == slot ? true : false))
+					const position = state.state.media.stillPool.findIndex((still) => still?.fileName == slot)
 					await atem?.setMediaPlayerSource(
 						{
 							sourceType: Enums.MediaSourceType.Still,


### PR DESCRIPTION
"Media player: Set source from variables" only supported media pool index numbers in the variable.
This adds the ability to also select by the name by iterating though the list of available Stills or Clips and choosing the first one that exactly matches the slot value.

I found myself wanting to change the lower third graphic depending on a custom name field in ontime though a Trigger, but could not directly do that. Also allows configuring names for static graphics without knowing exactly in which slot they are.

Tested with an Atem Mini Extreme Pro ISO with Stills, support for Clips is added but could not be tested.
This should also be backwards compatible.