### PR TITLE
SuperSource & DVE Transitions

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -71,12 +71,12 @@ export function GetActionsList(
 		...createProgramPreviewActions(atem, model, transitions, state),
 		...createTransitionActions(instance, atem, model, commandBatching, state),
 		...createUpstreamKeyerCommonActions(atem, model, state),
-		...createUpstreamKeyerDVEActions(atem, model, state),
+		...createUpstreamKeyerDVEActions(atem, model, transitions, state),
 		...createFadeToBlackActions(atem, model, state),
 
 		...createDownstreamKeyerActions(atem, model, state),
 		...createMacroActions(atem, model, state),
-		...createSuperSourceActions(atem, model, state),
+		...createSuperSourceActions(atem, model, transitions, state),
 		...createStreamingActions(atem, model, state),
 		...createRecordingActions(atem, model, state),
 

--- a/src/actions/mixeffect/upstreamKeyerDVE.ts
+++ b/src/actions/mixeffect/upstreamKeyerDVE.ts
@@ -5,6 +5,7 @@ import {
 	AtemUSKDVEPropertiesVariablesPickers,
 	AtemUSKPicker,
 	AtemUSKKeyframePropertiesPickers,
+	AtemTransitionAnimationOptions,
 } from '../../input.js'
 import type { ModelSpec } from '../../models/index.js'
 import { ActionId } from '../ActionId.js'
@@ -15,11 +16,17 @@ import type {
 	UpstreamKeyerDVESettings,
 	UpstreamKeyerFlyKeyframe,
 } from 'atem-connection/dist/state/video/upstreamKeyers.js'
+import type { algorithm, curve } from '../../easings.js'
+import type { AtemTransitions } from '../../transitions.js'
 
 export interface AtemUpstreamKeyerDVEActions {
 	[ActionId.USKDVEProperties]: {
 		mixeffect: number
 		key: number
+
+		transitionRate: number | undefined
+		transitionEasing: algorithm | undefined
+		transitionCurve: curve | undefined
 
 		properties: Array<
 			| 'positionX'
@@ -80,6 +87,10 @@ export interface AtemUpstreamKeyerDVEActions {
 	[ActionId.USKDVEPropertiesVariables]: {
 		mixeffect: string
 		key: string
+
+		transitionRate: number | undefined
+		transitionEasing: algorithm | undefined
+		transitionCurve: curve | undefined
 
 		properties: Array<
 			| 'positionX'
@@ -210,6 +221,7 @@ export interface AtemUpstreamKeyerDVEActions {
 export function createUpstreamKeyerDVEActions(
 	atem: Atem | undefined,
 	model: ModelSpec,
+	transitions: AtemTransitions,
 	state: StateWrapper,
 ): MyActionDefinitions<AtemUpstreamKeyerDVEActions> {
 	if (!model.USKs || !model.DVEs) {
@@ -229,6 +241,7 @@ export function createUpstreamKeyerDVEActions(
 			options: {
 				mixeffect: AtemMEPicker(model, 0),
 				key: AtemUSKPicker(model),
+				...AtemTransitionAnimationOptions(),
 				...AtemUSKDVEPropertiesPickers(),
 			},
 			callback: async ({ options }) => {
@@ -320,7 +333,39 @@ export function createUpstreamKeyerDVEActions(
 
 				if (Object.keys(newProps).length === 0) return
 
-				await atem?.setUpstreamKeyerDVESettings(newProps, mixEffectId, keyId)
+				await transitions.runForProperties(
+					`me.${mixEffectId}.keyer.${keyId}.dveSettings`,
+					async (props) => {
+						await atem?.setUpstreamKeyerDVESettings(props, mixEffectId, keyId)
+					},
+					options,
+					[
+						'positionX',
+						'positionY',
+						'sizeX',
+						'sizeY',
+						'rotation',
+						'maskTop',
+						'maskBottom',
+						'maskLeft',
+						'maskRight',
+						'lightSourceDirection',
+						'lightSourceAltitude',
+						'borderHue',
+						'borderSaturation',
+						'borderLuma',
+						'borderBevel',
+						'borderOuterWidth',
+						'borderInnerWidth',
+						'borderOuterSoftness',
+						'borderInnerSoftness',
+						'borderOpacity',
+						'borderBevelPosition',
+						'borderBevelSoftness',
+					],
+					newProps,
+					state.state.video.mixEffects[mixEffectId]?.upstreamKeyers[keyId]?.dveSettings,
+				)
 			},
 			learn: ({ options }) => {
 				const usk = getUSK(state.state, options.getPlainNumber('mixeffect'), options.getPlainNumber('key'))
@@ -377,6 +422,7 @@ export function createUpstreamKeyerDVEActions(
 					default: '1',
 					useVariables: true,
 				},
+				...AtemTransitionAnimationOptions(),
 				...AtemUSKDVEPropertiesVariablesPickers(),
 			},
 			callback: async ({ options }) => {
@@ -469,7 +515,39 @@ export function createUpstreamKeyerDVEActions(
 				if (isNaN(mixEffectId) || isNaN(keyId)) return
 				if (Object.keys(newProps).length === 0) return
 
-				await atem?.setUpstreamKeyerDVESettings(newProps, mixEffectId, keyId)
+				await transitions.runForProperties(
+					`me.${mixEffectId}.keyer.${keyId}.dveSettings`,
+					async (props) => {
+						await atem?.setUpstreamKeyerDVESettings(props, mixEffectId, keyId)
+					},
+					options,
+					[
+						'positionX',
+						'positionY',
+						'sizeX',
+						'sizeY',
+						'rotation',
+						'maskTop',
+						'maskBottom',
+						'maskLeft',
+						'maskRight',
+						'lightSourceDirection',
+						'lightSourceAltitude',
+						'borderHue',
+						'borderSaturation',
+						'borderLuma',
+						'borderBevel',
+						'borderOuterWidth',
+						'borderInnerWidth',
+						'borderOuterSoftness',
+						'borderInnerSoftness',
+						'borderOpacity',
+						'borderBevelPosition',
+						'borderBevelSoftness',
+					],
+					newProps,
+					state.state.video.mixEffects[mixEffectId]?.upstreamKeyers[keyId]?.dveSettings,
+				)
 			},
 			learn: async ({ options }) => {
 				const mixeffect = (await options.getParsedNumber('mixeffect')) - 1

--- a/src/input.ts
+++ b/src/input.ts
@@ -1201,6 +1201,65 @@ export function AtemAuxSourcePicker(model: ModelSpec, state: AtemState): Compani
 		choices: SourcesToChoices(GetSourcesListForType(model, state, 'aux')),
 	}
 }
+export function AtemTransitionAnimationOptions(): {
+	transitionRate: CompanionInputFieldNumber
+	transitionEasing: CompanionInputFieldDropdown
+	transitionCurve: CompanionInputFieldDropdown
+} {
+	return {
+		transitionRate: {
+			type: 'number',
+			id: 'transitionRate',
+			label: 'Transition Rate',
+			default: 0,
+			min: 0,
+			max: 99999,
+			step: 1,
+			required: false,
+		},
+		transitionEasing: {
+			type: 'dropdown',
+			label: 'Transition Easing',
+			id: 'transitionEasing',
+			default: 'linear',
+			choices: [
+				{ id: 'linear', label: 'Linear' },
+				{ id: 'quadratic', label: 'Quadratic' },
+				{ id: 'cubic', label: 'Cubic' },
+				{ id: 'quartic', label: 'Quartic' },
+				{ id: 'quintic', label: 'Quintic' },
+				{ id: 'sinusoidal', label: 'Sinusoidal' },
+				{ id: 'exponential', label: 'Exponential' },
+				{ id: 'circular', label: 'Circular' },
+				{ id: 'elastic', label: 'Elastic' },
+				{ id: 'back', label: 'Back' },
+				{ id: 'bounce', label: 'Bounce' },
+			],
+			isVisible: (options: CompanionOptionValues): boolean => {
+				return options.transitionRate != null && (options.transitionRate as number) > 0
+			},
+		},
+		transitionCurve: {
+			type: 'dropdown',
+			label: 'Transition curve',
+			id: 'transitionCurve',
+			default: 'ease-in',
+			choices: [
+				{ id: 'ease-in', label: 'Ease-in' },
+				{ id: 'ease-out', label: 'Ease-out' },
+				{ id: 'ease-in-out', label: 'Ease-in-out' },
+			],
+			isVisible: (options: CompanionOptionValues): boolean => {
+				return (
+					options.transitionRate != null &&
+					options.transitionEasing != null &&
+					(options.transitionRate as number) > 0 &&
+					(options.transitionEasing as string) !== 'linear'
+				)
+			},
+		},
+	}
+}
 export function AtemSuperSourceBoxPicker(): CompanionInputFieldDropdown {
 	return {
 		type: 'dropdown',

--- a/src/transitions.ts
+++ b/src/transitions.ts
@@ -1,11 +1,12 @@
 import type { MyOptionsHelper } from './common.js'
 import { fadeFpsDefault, type AtemConfig } from './config.js'
+import type { algorithm, curve } from './easings.js'
 import * as Easing from './easings.js'
 import type { FadeDurationFieldsType } from './input.js'
 
 export interface TransitionInfo {
-	sendFcn: (value: number) => Promise<void>
-	steps: number[]
+	sendFcn: (value: number[]) => Promise<void>
+	steps: number[][]
 }
 
 export class AtemTransitions {
@@ -56,7 +57,7 @@ export class AtemTransitions {
 
 	public async runForFadeOptions(
 		id: string,
-		sendFcn: TransitionInfo['sendFcn'],
+		sendFcn: (value: number) => Promise<void>,
 		from: number | undefined,
 		to: number,
 		options: MyOptionsHelper<FadeDurationFieldsType>,
@@ -66,14 +67,58 @@ export class AtemTransitions {
 		const algorithm = options.getPlainString('fadeAlgorithm')
 		const curve = options.getPlainString('fadeCurve')
 
-		return this.run(id, sendFcn, from, to, duration, algorithm, curve)
+		return this.run(id, async ([value]) => sendFcn(value), [from], [to], duration, algorithm, curve)
+	}
+
+	public async runForProperties<T extends object>(
+		id: string,
+		sendFcn: (properties: T) => Promise<void>,
+		options: MyOptionsHelper<{
+			transitionRate: number | undefined
+			transitionEasing: algorithm | undefined
+			transitionCurve: curve | undefined
+		}>,
+		animatedKeys: string[],
+		newProps: T,
+		oldProps: T | undefined,
+	): Promise<void> {
+		const transitionRate = options.getRaw('transitionRate')
+
+		if (transitionRate && oldProps) {
+			// filter out the keys that we can animate
+			const keys = Object.keys(newProps).filter((key) => animatedKeys.includes(key)) as (keyof T)[]
+
+			// gather the from and to values from the objects
+			const from = keys.map((key) => oldProps[key])
+			const to = keys.map((key) => newProps[key])
+
+			const isOnlyNumbers = (array: any[]): array is number[] => !array.find((value) => typeof value !== 'number')
+
+			if (from.length === to.length && isOnlyNumbers(from) && isOnlyNumbers(to)) {
+				// we can safely tween between these values
+				return this.run(
+					id,
+					async (values) => {
+						// reconstruct the properties with the tweened values
+						return sendFcn({ ...newProps, ...Object.fromEntries(values.map((val, i) => [keys[i], val])) })
+					},
+					from,
+					to,
+					transitionRate,
+					options.getRaw('transitionEasing'),
+					options.getRaw('transitionCurve'),
+				)
+			}
+		}
+
+		return sendFcn(newProps)
 	}
 
 	public async run(
 		id: string,
 		sendFcn: TransitionInfo['sendFcn'],
-		from: number | undefined,
-		to: number,
+		from: (number | undefined)[],
+		to: number[],
 		duration: number,
 		algorithm?: Easing.algorithm,
 		curve?: Easing.curve,
@@ -82,16 +127,16 @@ export class AtemTransitions {
 		const stepCount = Math.ceil(duration / interval)
 
 		// TODO - what if not sending db
-		if (stepCount <= 1 || typeof from !== 'number') {
+		if (stepCount <= 1 || from.reduce((a, b) => (a === undefined ? a : b)) === undefined) {
 			this.transitions.delete(id)
 			await sendFcn(to)
 		} else {
-			const diff = to - from
-			const steps: number[] = []
+			const diff = to.map((to, i) => to - (from[i] ?? 0))
+			const steps: number[][] = []
 			const easing = Easing.getEasing(algorithm, curve)
 			for (let i = 1; i <= stepCount; i++) {
 				const fraction = easing(i / stepCount)
-				steps.push(from + diff * fraction)
+				steps.push(from.map((from, i) => (from === undefined ? to[i] : from + diff[i] * fraction)))
 			}
 
 			this.transitions.set(id, {


### PR DESCRIPTION
This PR changes the following

- A step in the AtemTransitions class can now contain multiple values
- A convenience method on the AtemTransitions class that will return a  properties object with tweened values (Note: the developer must specify which values are to be tweened)
- Options for the DVE properties and the SuperSource Box properties to enable the transitions

Further notes

- As tested with a Constellation 2M/E controlled over wifi and no other companion modules enabled I did not see major performance issues, however occasionally 1 frame would drop. It was really only noticeable with slow movements.
- As there is no motion blur it is best to run these animations at the frame rate of the switcher
- I struggled a bit with the typings for the convenience method, the property names are not type safe. This shouldn't cause any production bugs, just an inconvenience to developers.

---

This PR implements #144 