### PR TITLE
feat: Add On Air option for downstream keys

### DIFF
--- a/src/actions/dsk.ts
+++ b/src/actions/dsk.ts
@@ -50,6 +50,7 @@ export interface AtemDownstreamKeyerActions {
 	}
 	[ActionId.DSKAuto]: {
 		downstreamKeyerId: number
+		onair: TrueFalseToggle
 	}
 	[ActionId.DSKOnAir]: {
 		key: number
@@ -284,9 +285,18 @@ export function createDownstreamKeyerActions(
 					default: 0,
 					choices: GetDSKIdChoices(model),
 				},
+				onair: {
+					id: 'onair',
+					type: 'dropdown',
+					label: 'On Air',
+					default: 'toggle',
+					choices: CHOICES_KEYTRANS,
+				},
 			},
 			callback: async ({ options }) => {
-				await atem?.autoDownstreamKey(options.getPlainNumber('downstreamKeyerId'))
+				const onair = options.getPlainString('onair')
+				const towardOnAir = onair === 'toggle' ? undefined : onair === 'true'
+				await atem?.autoDownstreamKey(options.getPlainNumber('downstreamKeyerId'), towardOnAir)
 			},
 		},
 		[ActionId.DSKOnAir]: {


### PR DESCRIPTION
Instead of always toggling the DSK, add an option between On Air, Off, and Toggle.

Tested on a 2 M/E Constellation HD.