### PR TITLE
fix: add (ms) to transition label

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -1219,7 +1219,7 @@ export function AtemTransitionAnimationOptions(): {
 		transitionRate: {
 			type: 'number',
 			id: 'transitionRate',
-			label: 'Transition Rate',
+			label: 'Transition Rate (ms)',
 			default: 0,
 			min: 0,
 			max: 99999,


### PR DESCRIPTION
A small rename of the new _Transition Rate_ for DVEs and SuperSources to make it obvious that it should be in ms, not seconds or frames.

This should be now consistent with the _Fade Duration (ms)_ label.

Just because I spent a lot of time trying to discover this 😆 