### PR TITLE
feat: add on-air variables for USK and DSK

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -360,7 +360,11 @@ export default class AtemInstance extends InstanceBase<AtemSchema> {
 				continue
 			}
 
-			if (path.match(/video.mixEffects.(\d+).upstreamKeyers.(\d+).onAir/)) {
+			const uskOnAirMatch = path.match(/video.mixEffects.(\d+).upstreamKeyers.(\d+).onAir/)
+			if (uskOnAirMatch) {
+				const meIndex = parseInt(uskOnAirMatch[1], 10)
+				const keyIndex = parseInt(uskOnAirMatch[2], 10)
+				changedVariables.usk.add([meIndex, keyIndex])
 				changedFeedbacks.add('uskOnAir')
 				continue
 			}

--- a/src/variables/lib.ts
+++ b/src/variables/lib.ts
@@ -137,6 +137,7 @@ function updateUSKVariable(
 	const input = getUSK(state, meIndex, keyIndex)?.fillSource ?? 0
 	values[`usk_${meIndex + 1}_${keyIndex + 1}_input`] = getSourcePresetName(instance, state, input)
 	values[`usk_${meIndex + 1}_${keyIndex + 1}_input_id`] = input
+	values[`pgm${meIndex + 1}_usk_${keyIndex + 1}_onAir`] = !!getUSK(state, meIndex, keyIndex)?.onAir
 	const dveSettings = state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]?.dveSettings
 	if (dveSettings) {
 		values[`usk_${meIndex + 1}_${keyIndex + 1}_maskEnabled`] = dveSettings.maskEnabled
@@ -190,6 +191,7 @@ function updateDSKVariable(
 	const input = getDSK(state, keyIndex)?.sources?.fillSource ?? 0
 	values[`dsk_${keyIndex + 1}_input`] = getSourcePresetName(instance, state, input)
 	values[`dsk_${keyIndex + 1}_input_id`] = input
+	values[`dsk_${keyIndex + 1}_onAir`] = !!getDSK(state, keyIndex)?.onAir
 }
 
 function updateAuxVariable(
@@ -462,6 +464,9 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 			variables[`usk_${i + 1}_${k + 1}_input_id`] = {
 				name: `Id of input active on M/E ${i + 1} Key ${k + 1}`,
 			}
+			variables[`pgm${i + 1}_usk_${k + 1}_onAir`] = {
+				name: `On Air state of M/E ${i + 1} Key ${k + 1}`,
+			}
 			if (model.USKs && model.DVEs) {
 				variables[`usk_${i + 1}_${k + 1}_maskEnabled`] = {
 					name: `Mask Enabled for M/E ${i + 1} Key ${k + 1}`,
@@ -587,6 +592,9 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 		}
 		variables[`dsk_${k + 1}_input_id`] = {
 			name: `Id of input active on DSK ${k + 1}`,
+		}
+		variables[`dsk_${k + 1}_onAir`] = {
+			name: `On Air state of DSK ${k + 1}`,
 		}
 
 		updateDSKVariable(instance, state.state, k, values)

--- a/src/variables/schema.ts
+++ b/src/variables/schema.ts
@@ -44,11 +44,14 @@ export type VariablesSchema = {
 	[key: `usk_${number}_${number}_canFlyKey`]: boolean | undefined
 	[key: `usk_${number}_${number}_flyEnabled`]: boolean | undefined
 
+	[key: `pgm${number}_usk_${number}_onAir`]: boolean
+
 	[key: `aux${number}_input`]: string
 	[key: `aux${number}_input_id`]: number
 
 	[key: `dsk_${number}_input`]: string
 	[key: `dsk_${number}_input_id`]: number
+	[key: `dsk_${number}_onAir`]: boolean
 
 	[key: `long_${number}`]: string
 	[key: `short_${number}`]: string


### PR DESCRIPTION
## Summary
- Add `pgm<me>_usk_<key>_onAir` boolean variable for each upstream keyer
- Add `dsk_<key>_onAir` boolean variable for each downstream keyer