### PR TITLE
feat: Add still/clip name to slot resolver vars

### DIFF
--- a/src/variables/lib.ts
+++ b/src/variables/lib.ts
@@ -266,14 +266,22 @@ function updateMacroVariable(state: AtemState, id: number, values: Partial<Varia
 	values[`macro_${id + 1}`] = macro?.name || `Macro ${id + 1}`
 }
 
-function updateMediaStillVariable(state: AtemState, id: number, values: Partial<VariablesSchema>): void {
+function updateMediaStillVariable(state: AtemState, id: number, variables: CompanionVariableDefinitions<VariablesSchema>, values: Partial<VariablesSchema>): void {
 	const still = state.media.stillPool[id]
 	values[`still_${id + 1}`] = still?.fileName || `Still ${id + 1}`
+	if (still?.fileName) {
+		variables[`still_name_${still?.fileName}`] = {name: "Slot name of still with file name still_name_<filename>"}
+		values[`still_name_${still?.fileName}`] = `Still ${id + 1}`
+	}
 }
 
-function updateMediaClipVariable(state: AtemState, id: number, values: Partial<VariablesSchema>): void {
+function updateMediaClipVariable(state: AtemState, id: number, variables: CompanionVariableDefinitions<VariablesSchema>, values: Partial<VariablesSchema>): void {
 	const clip = state.media.clipPool[id]
 	values[`clip_${id + 1}`] = clip?.name || `Clip ${id + 1}`
+	if (clip?.name) {
+		variables[`clip_name_${clip?.name}`] = {name: "Slot name of clip with file name clip_name_<filename>"}
+		values[`clip_name_${clip?.name}`] = `Clip ${id + 1}`
+	}
 }
 
 function updateMediaPlayerVariables(state: AtemState, id: number, values: Partial<VariablesSchema>): void {
@@ -764,14 +772,14 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 			name: `Name of still #${i + 1}`,
 		}
 
-		updateMediaStillVariable(state.state, i, values)
+		updateMediaStillVariable(state.state, i, variables, values)
 	}
 	for (let i = 0; i < model.media.clips; i++) {
 		variables[`clip_${i + 1}`] = {
 			name: `Name of clip #${i + 1}`,
 		}
 
-		updateMediaClipVariable(state.state, i, values)
+		updateMediaClipVariable(state.state, i, variables, values)
 	}
 	for (let i = 0; i < model.media.players; i++) {
 		variables[`mp_source_${i + 1}`] = {

--- a/src/variables/schema.ts
+++ b/src/variables/schema.ts
@@ -81,7 +81,9 @@ export type VariablesSchema = {
 	[key: `macro_${number}`]: string
 
 	[key: `still_${number}`]: string
+	[key: `still_name_${string}`]: string
 	[key: `clip_${number}`]: string
+	[key: `clip_name_${string}`]: string
 
 	[key: `mp_source_${number}`]: string
 	[key: `mp_index_${number}`]: string


### PR DESCRIPTION
This is a re-implementation of #374 which got lost in the module api 2.0 updates.
But this time it's implemented differently, in the (in my opinion) least intrusive and backwards compatible way possible:
For each Still or Clip slot with a valid filename (aka there is content), a new companion variable is created in the form of still/clip_name_<filename>.
This variable resolves to the special strings "Still x" and "Clip x" that are used internally for the "Media player: Set source" action (and existing variables).
<img width="982" height="243" alt="image" src="https://github.com/user-attachments/assets/dc1e066c-f466-4292-8b0b-b9d6723f8c78" />
With that the full variable can be manually used in input fields, or dynamically with content (the filename) from a different variable with this expression: `parseVariables('$(atem_2:still_name_$(custom:lowerThirdName))')`

I'm totally open to changing how it's implemented, for example to work like initially implemented in #374 or something else entirely. Not really a typescript person so hope the types are all correct, at least the compiler didn't yell at me.

Still support is tested, clips i can't test myself but are implemented the same way.