### PR TITLE
feat(variables): add advanced SuperSource variables (art option, border)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,9 @@ export type AtemConfig = {
 
 	enableCameraControl?: boolean
 	pollTimecode?: boolean
+	enableAdvancedSuperSourceVariables?: boolean
+	enableAdvancedUskVariables?: boolean
+	enableAudioRoutingVariables?: boolean
 }
 
 export function GetConfigFields(config: AtemConfig): SomeCompanionConfigField[] {
@@ -101,6 +104,30 @@ export function GetConfigFields(config: AtemConfig): SomeCompanionConfigField[] 
 			type: 'checkbox',
 			id: 'pollTimecode',
 			label: 'Enable Timecode variable',
+			width: 6,
+			default: false,
+		},
+		{
+			type: 'checkbox',
+			id: 'enableAdvancedSuperSourceVariables',
+			label: 'Enable advanced SuperSource variables',
+			tooltip: 'Adds extra variables for SuperSource art placement and border settings',
+			width: 6,
+			default: false,
+		},
+		{
+			type: 'checkbox',
+			id: 'enableAdvancedUskVariables',
+			label: 'Enable advanced USK variables',
+			tooltip: 'Adds extra variables for the detailed USK DVE/pattern/luma/chroma settings',
+			width: 6,
+			default: false,
+		},
+		{
+			type: 'checkbox',
+			id: 'enableAudioRoutingVariables',
+			label: 'Enable audio routing variables',
+			tooltip: 'Adds extra variables for Fairlight audio routing sources and destinations',
 			width: 6,
 			default: false,
 		},

--- a/src/main.ts
+++ b/src/main.ts
@@ -452,6 +452,11 @@ export default class AtemInstance extends InstanceBase<AtemSchema> {
 				changedFeedbacks.add('ssrc_art_properties')
 				continue
 			}
+			const ssrcBorderMatch = path.match(/video.superSources.(\d+).border/)
+			if (ssrcBorderMatch) {
+				changedVariables.ssrc.add(parseInt(ssrcBorderMatch[1], 10))
+				continue
+			}
 
 			const transitionPropertiesMatch = path.match(/video.mixEffects.(\d+).transitionProperties/)
 			if (transitionPropertiesMatch) {

--- a/src/variables/lib.ts
+++ b/src/variables/lib.ts
@@ -91,10 +91,12 @@ export function updateChangedVariables(
 	for (const classicAudioIndex of changes.classicAudio) updateClassicAudioVariables(state, classicAudioIndex, newValues)
 	if (changes.fairlightAudioMaster) updateFairlightAudioMasterVariables(state, newValues)
 	if (changes.fairlightAudioMonitor) updateFairlightAudioMonitorVariables(state, newValues)
-	for (const sourceId of changes.fairlightRoutingSources)
-		updateFairlightAudioRoutingSourceVariables(state, sourceId, newValues)
-	for (const outputId of changes.fairlightRoutingOutputs)
-		updateFairlightAudioRoutingOutputVariables(state, outputId, newValues)
+	if (instance.config.enableAudioRoutingVariables) {
+		for (const sourceId of changes.fairlightRoutingSources)
+			updateFairlightAudioRoutingSourceVariables(state, sourceId, newValues)
+		for (const outputId of changes.fairlightRoutingOutputs)
+			updateFairlightAudioRoutingOutputVariables(state, outputId, newValues)
+	}
 
 	for (const [index, window] of changes.mvWindow)
 		updateMultiviewerWindowInput(instance, state, index, window, newValues)
@@ -174,62 +176,68 @@ function updateUSKVariable(
 	values[`pgm${meIndex + 1}_usk_${keyIndex + 1}_onAir`] = !!getUSK(state, meIndex, keyIndex)?.onAir
 	const dveSettings = state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]?.dveSettings
 	if (dveSettings) {
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_maskEnabled`] = dveSettings.maskEnabled
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_maskTop`] = dveSettings.maskTop / 1000
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_maskBottom`] = dveSettings.maskBottom / 1000
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_maskLeft`] = dveSettings.maskLeft / 1000
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_maskRight`] = dveSettings.maskRight / 1000
 		values[`usk_${meIndex + 1}_${keyIndex + 1}_positionX`] = dveSettings.positionX / 1000
 		values[`usk_${meIndex + 1}_${keyIndex + 1}_positionY`] = dveSettings.positionY / 1000
 		values[`usk_${meIndex + 1}_${keyIndex + 1}_sizeX`] = dveSettings.sizeX / 1000
 		values[`usk_${meIndex + 1}_${keyIndex + 1}_sizeY`] = dveSettings.sizeY / 1000
 		values[`usk_${meIndex + 1}_${keyIndex + 1}_rotation`] = dveSettings.rotation / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_bordOutWidth`] = dveSettings.borderOuterWidth / 100
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_bordInWidth`] = dveSettings.borderInnerWidth / 100
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_bordOutSoft`] = dveSettings.borderOuterSoftness
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_bordInSoft`] = dveSettings.borderInnerSoftness
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_bevelSoft`] = dveSettings.borderBevelSoftness
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_bevelPos`] = dveSettings.borderBevelPosition
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_bordOpacity`] = dveSettings.borderOpacity
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_bordHue`] = dveSettings.borderHue / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_bordSat`] = dveSettings.borderSaturation / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_bordLum`] = dveSettings.borderLuma / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_lightDirection`] = dveSettings.lightSourceDirection / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_lightAltitude`] = dveSettings.lightSourceAltitude
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_bordEnabled`] = dveSettings.borderEnabled
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_shadowEnabled`] = dveSettings.shadowEnabled
 		values[`usk_${meIndex + 1}_${keyIndex + 1}_rate`] = dveSettings.rate
+
+		if (instance.config.enableAdvancedUskVariables) {
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_maskEnabled`] = dveSettings.maskEnabled
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_maskTop`] = dveSettings.maskTop / 1000
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_maskBottom`] = dveSettings.maskBottom / 1000
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_maskLeft`] = dveSettings.maskLeft / 1000
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_maskRight`] = dveSettings.maskRight / 1000
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_bordOutWidth`] = dveSettings.borderOuterWidth / 100
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_bordInWidth`] = dveSettings.borderInnerWidth / 100
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_bordOutSoft`] = dveSettings.borderOuterSoftness
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_bordInSoft`] = dveSettings.borderInnerSoftness
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_bevelSoft`] = dveSettings.borderBevelSoftness
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_bevelPos`] = dveSettings.borderBevelPosition
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_bordOpacity`] = dveSettings.borderOpacity
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_bordHue`] = dveSettings.borderHue / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_bordSat`] = dveSettings.borderSaturation / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_bordLum`] = dveSettings.borderLuma / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_lightDirection`] = dveSettings.lightSourceDirection / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_lightAltitude`] = dveSettings.lightSourceAltitude
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_bordEnabled`] = dveSettings.borderEnabled
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_shadowEnabled`] = dveSettings.shadowEnabled
+		}
 	}
-	const patternSettings = state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]?.patternSettings
-	if (patternSettings) {
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_style`] = patternSettings.style
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_size`] = patternSettings.size / 100
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_symmetry`] = patternSettings.symmetry / 100
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_softness`] = patternSettings.softness / 100
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_positionX`] = patternSettings.positionX / 10000
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_positionY`] = patternSettings.positionY / 10000
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_invert`] = patternSettings.invert
-	}
-	const lumaSettings = state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]?.lumaSettings
-	if (lumaSettings) {
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_luma_preMultiplied`] = lumaSettings.preMultiplied
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_luma_clip`] = lumaSettings.clip / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_luma_gain`] = lumaSettings.gain / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_luma_invert`] = lumaSettings.invert
-	}
-	const chromaProperties = state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]?.advancedChromaSettings?.properties
-	if (chromaProperties) {
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_foregroundLevel`] = chromaProperties.foregroundLevel / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_backgroundLevel`] = chromaProperties.backgroundLevel / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_keyEdge`] = chromaProperties.keyEdge / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_spillSuppression`] = chromaProperties.spillSuppression / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_flareSuppression`] = chromaProperties.flareSuppression / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_brightness`] = chromaProperties.brightness / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_contrast`] = chromaProperties.contrast / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_saturation`] = chromaProperties.saturation / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_red`] = chromaProperties.red / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_green`] = chromaProperties.green / 10
-		values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_blue`] = chromaProperties.blue / 10
+	if (instance.config.enableAdvancedUskVariables) {
+		const patternSettings = state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]?.patternSettings
+		if (patternSettings) {
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_style`] = patternSettings.style
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_size`] = patternSettings.size / 100
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_symmetry`] = patternSettings.symmetry / 100
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_softness`] = patternSettings.softness / 100
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_positionX`] = patternSettings.positionX / 10000
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_positionY`] = patternSettings.positionY / 10000
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_pattern_invert`] = patternSettings.invert
+		}
+		const lumaSettings = state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]?.lumaSettings
+		if (lumaSettings) {
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_luma_preMultiplied`] = lumaSettings.preMultiplied
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_luma_clip`] = lumaSettings.clip / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_luma_gain`] = lumaSettings.gain / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_luma_invert`] = lumaSettings.invert
+		}
+		const chromaProperties =
+			state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]?.advancedChromaSettings?.properties
+		if (chromaProperties) {
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_foregroundLevel`] = chromaProperties.foregroundLevel / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_backgroundLevel`] = chromaProperties.backgroundLevel / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_keyEdge`] = chromaProperties.keyEdge / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_spillSuppression`] = chromaProperties.spillSuppression / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_flareSuppression`] = chromaProperties.flareSuppression / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_brightness`] = chromaProperties.brightness / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_contrast`] = chromaProperties.contrast / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_saturation`] = chromaProperties.saturation / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_red`] = chromaProperties.red / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_green`] = chromaProperties.green / 10
+			values[`usk_${meIndex + 1}_${keyIndex + 1}_chroma_blue`] = chromaProperties.blue / 10
+		}
 	}
 	if (state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]) {
 		values[`usk_${meIndex + 1}_${keyIndex + 1}_canFlyKey`] =
@@ -477,6 +485,30 @@ function updateSuperSourceVariables(
 		values[`ssrc${i + 1}_box${b + 1}_cropLeft`] = (box?.cropLeft ?? 0) / 1000
 		values[`ssrc${i + 1}_box${b + 1}_cropRight`] = (box?.cropRight ?? 0) / 1000
 	}
+
+	if (instance.config.enableAdvancedSuperSourceVariables) {
+		values[`ssrc${i + 1}_art_option`] =
+			properties?.artOption === Enums.SuperSourceArtOption.Foreground ? 'Foreground' : 'Background'
+		values[`ssrc${i + 1}_art_preMultiplied`] = properties?.artPreMultiplied
+		values[`ssrc${i + 1}_art_clip`] = properties ? properties.artClip / 10 : undefined
+		values[`ssrc${i + 1}_art_gain`] = properties ? properties.artGain / 10 : undefined
+		values[`ssrc${i + 1}_art_invertKey`] = properties?.artInvertKey
+
+		const border = state.video.superSources?.[i]?.border
+		values[`ssrc${i + 1}_border_enabled`] = border?.borderEnabled
+		values[`ssrc${i + 1}_border_bevel`] = border?.borderBevel
+		values[`ssrc${i + 1}_border_outWidth`] = border ? border.borderOuterWidth / 100 : undefined
+		values[`ssrc${i + 1}_border_inWidth`] = border ? border.borderInnerWidth / 100 : undefined
+		values[`ssrc${i + 1}_border_outSoft`] = border?.borderOuterSoftness
+		values[`ssrc${i + 1}_border_inSoft`] = border?.borderInnerSoftness
+		values[`ssrc${i + 1}_border_bevelSoft`] = border?.borderBevelSoftness
+		values[`ssrc${i + 1}_border_bevelPos`] = border?.borderBevelPosition
+		values[`ssrc${i + 1}_border_hue`] = border ? border.borderHue / 10 : undefined
+		values[`ssrc${i + 1}_border_sat`] = border ? border.borderSaturation / 10 : undefined
+		values[`ssrc${i + 1}_border_lum`] = border ? border.borderLuma / 10 : undefined
+		values[`ssrc${i + 1}_border_lightDirection`] = border ? border.borderLightSourceDirection / 10 : undefined
+		values[`ssrc${i + 1}_border_lightAltitude`] = border?.borderLightSourceAltitude
+	}
 }
 
 function updateMultiviewerWindowInput(
@@ -556,21 +588,6 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 				name: `On Air state of M/E ${i + 1} Key ${k + 1}`,
 			}
 			if (model.USKs && model.DVEs) {
-				variables[`usk_${i + 1}_${k + 1}_maskEnabled`] = {
-					name: `Mask Enabled for M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_maskTop`] = {
-					name: `Mask cutoff from the top of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_maskBottom`] = {
-					name: `Mask cutoff from the bottom of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_maskLeft`] = {
-					name: `Mask cutoff from the left of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_maskRight`] = {
-					name: `Mask cutoff from the right of M/E ${i + 1} Key ${k + 1}`,
-				}
 				variables[`usk_${i + 1}_${k + 1}_positionX`] = {
 					name: `X position of M/E ${i + 1} Key ${k + 1}`,
 				}
@@ -586,71 +603,8 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 				variables[`usk_${i + 1}_${k + 1}_rotation`] = {
 					name: `Rotation of M/E ${i + 1} Key ${k + 1}`,
 				}
-				variables[`usk_${i + 1}_${k + 1}_bordOutWidth`] = {
-					name: `Border Width (Outer) of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_bordInWidth`] = {
-					name: `Border Width (Inner) of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_bordOutSoft`] = {
-					name: `Border Softness (Outer) of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_bordInSoft`] = {
-					name: `Border Softnesss (Inner) of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_bevelSoft`] = {
-					name: `Border Bevel Softnesss of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_bevelPos`] = {
-					name: `Border Bevel Position of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_bordOpacity`] = {
-					name: `Border Opacity of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_bordHue`] = {
-					name: `Border Hue of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_bordSat`] = {
-					name: `Border Saturation of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_bordLum`] = {
-					name: `Border Luma of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_lightDirection`] = {
-					name: `Light source Angle of shadow of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_lightAltitude`] = {
-					name: `Light source Altitude of shadow of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_bordEnabled`] = {
-					name: `Border Enabled for M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_shadowEnabled`] = {
-					name: `Shadow Enabled for M/E ${i + 1} Key ${k + 1}`,
-				}
 				variables[`usk_${i + 1}_${k + 1}_rate`] = {
 					name: `Keyframe transformation Rate of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_pattern_style`] = {
-					name: `Pattern Style of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_pattern_size`] = {
-					name: `Pattern Size of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_pattern_symmetry`] = {
-					name: `Pattern Symmetry of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_pattern_softness`] = {
-					name: `Pattern Softness of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_pattern_positionX`] = {
-					name: `Pattern Position X of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_pattern_positionY`] = {
-					name: `Pattern Position Y of M/E ${i + 1} Key ${k + 1}`,
-				}
-				variables[`usk_${i + 1}_${k + 1}_pattern_invert`] = {
-					name: `Pattern Invert of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_canFlyKey`] = {
 					name: `(read only) Ability to Enable Fly Key or DVE of M/E ${i + 1} Key ${k + 1}`,
@@ -658,52 +612,135 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 				variables[`usk_${i + 1}_${k + 1}_flyEnabled`] = {
 					name: `Fly Key Enable Status of M/E ${i + 1} Key ${k + 1}`,
 				}
+
+				if (instance.config.enableAdvancedUskVariables) {
+					variables[`usk_${i + 1}_${k + 1}_maskEnabled`] = {
+						name: `Mask Enabled for M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_maskTop`] = {
+						name: `Mask cutoff from the top of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_maskBottom`] = {
+						name: `Mask cutoff from the bottom of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_maskLeft`] = {
+						name: `Mask cutoff from the left of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_maskRight`] = {
+						name: `Mask cutoff from the right of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_bordOutWidth`] = {
+						name: `Border Width (Outer) of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_bordInWidth`] = {
+						name: `Border Width (Inner) of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_bordOutSoft`] = {
+						name: `Border Softness (Outer) of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_bordInSoft`] = {
+						name: `Border Softnesss (Inner) of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_bevelSoft`] = {
+						name: `Border Bevel Softnesss of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_bevelPos`] = {
+						name: `Border Bevel Position of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_bordOpacity`] = {
+						name: `Border Opacity of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_bordHue`] = {
+						name: `Border Hue of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_bordSat`] = {
+						name: `Border Saturation of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_bordLum`] = {
+						name: `Border Luma of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_lightDirection`] = {
+						name: `Light source Angle of shadow of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_lightAltitude`] = {
+						name: `Light source Altitude of shadow of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_bordEnabled`] = {
+						name: `Border Enabled for M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_shadowEnabled`] = {
+						name: `Shadow Enabled for M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_pattern_style`] = {
+						name: `Pattern Style of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_pattern_size`] = {
+						name: `Pattern Size of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_pattern_symmetry`] = {
+						name: `Pattern Symmetry of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_pattern_softness`] = {
+						name: `Pattern Softness of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_pattern_positionX`] = {
+						name: `Pattern Position X of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_pattern_positionY`] = {
+						name: `Pattern Position Y of M/E ${i + 1} Key ${k + 1}`,
+					}
+					variables[`usk_${i + 1}_${k + 1}_pattern_invert`] = {
+						name: `Pattern Invert of M/E ${i + 1} Key ${k + 1}`,
+					}
+				}
 			}
 
-			variables[`usk_${i + 1}_${k + 1}_luma_preMultiplied`] = {
-				name: `Luma Pre-multiplied of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_luma_clip`] = {
-				name: `Luma Clip of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_luma_gain`] = {
-				name: `Luma Gain of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_luma_invert`] = {
-				name: `Luma Invert of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_chroma_foregroundLevel`] = {
-				name: `Advanced Chroma Foreground Level of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_chroma_backgroundLevel`] = {
-				name: `Advanced Chroma Background Level of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_chroma_keyEdge`] = {
-				name: `Advanced Chroma Key Edge of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_chroma_spillSuppression`] = {
-				name: `Advanced Chroma Spill Suppression of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_chroma_flareSuppression`] = {
-				name: `Advanced Chroma Flare Suppression of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_chroma_brightness`] = {
-				name: `Advanced Chroma Brightness of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_chroma_contrast`] = {
-				name: `Advanced Chroma Contrast of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_chroma_saturation`] = {
-				name: `Advanced Chroma Saturation of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_chroma_red`] = {
-				name: `Advanced Chroma Red of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_chroma_green`] = {
-				name: `Advanced Chroma Green of M/E ${i + 1} Key ${k + 1}`,
-			}
-			variables[`usk_${i + 1}_${k + 1}_chroma_blue`] = {
-				name: `Advanced Chroma Blue of M/E ${i + 1} Key ${k + 1}`,
+			if (instance.config.enableAdvancedUskVariables) {
+				variables[`usk_${i + 1}_${k + 1}_luma_preMultiplied`] = {
+					name: `Luma Pre-multiplied of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_luma_clip`] = {
+					name: `Luma Clip of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_luma_gain`] = {
+					name: `Luma Gain of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_luma_invert`] = {
+					name: `Luma Invert of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_chroma_foregroundLevel`] = {
+					name: `Advanced Chroma Foreground Level of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_chroma_backgroundLevel`] = {
+					name: `Advanced Chroma Background Level of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_chroma_keyEdge`] = {
+					name: `Advanced Chroma Key Edge of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_chroma_spillSuppression`] = {
+					name: `Advanced Chroma Spill Suppression of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_chroma_flareSuppression`] = {
+					name: `Advanced Chroma Flare Suppression of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_chroma_brightness`] = {
+					name: `Advanced Chroma Brightness of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_chroma_contrast`] = {
+					name: `Advanced Chroma Contrast of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_chroma_saturation`] = {
+					name: `Advanced Chroma Saturation of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_chroma_red`] = {
+					name: `Advanced Chroma Red of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_chroma_green`] = {
+					name: `Advanced Chroma Green of M/E ${i + 1} Key ${k + 1}`,
+				}
+				variables[`usk_${i + 1}_${k + 1}_chroma_blue`] = {
+					name: `Advanced Chroma Blue of M/E ${i + 1} Key ${k + 1}`,
+				}
 			}
 
 			updateUSKVariable(instance, state.state, i, k, values)
@@ -901,6 +938,63 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 			}
 		}
 
+		if (instance.config.enableAdvancedSuperSourceVariables) {
+			variables[`ssrc${i + 1}_art_option`] = {
+				name: `Supersource ${i + 1} art placement (Foreground/Background)`,
+			}
+			variables[`ssrc${i + 1}_art_preMultiplied`] = {
+				name: `Supersource ${i + 1} art pre-multiplied`,
+			}
+			variables[`ssrc${i + 1}_art_clip`] = {
+				name: `Supersource ${i + 1} art clip`,
+			}
+			variables[`ssrc${i + 1}_art_gain`] = {
+				name: `Supersource ${i + 1} art gain`,
+			}
+			variables[`ssrc${i + 1}_art_invertKey`] = {
+				name: `Supersource ${i + 1} art invert key`,
+			}
+			variables[`ssrc${i + 1}_border_enabled`] = {
+				name: `Supersource ${i + 1} border enabled`,
+			}
+			variables[`ssrc${i + 1}_border_bevel`] = {
+				name: `Supersource ${i + 1} border bevel`,
+			}
+			variables[`ssrc${i + 1}_border_outWidth`] = {
+				name: `Supersource ${i + 1} border outer width`,
+			}
+			variables[`ssrc${i + 1}_border_inWidth`] = {
+				name: `Supersource ${i + 1} border inner width`,
+			}
+			variables[`ssrc${i + 1}_border_outSoft`] = {
+				name: `Supersource ${i + 1} border outer softness`,
+			}
+			variables[`ssrc${i + 1}_border_inSoft`] = {
+				name: `Supersource ${i + 1} border inner softness`,
+			}
+			variables[`ssrc${i + 1}_border_bevelSoft`] = {
+				name: `Supersource ${i + 1} border bevel softness`,
+			}
+			variables[`ssrc${i + 1}_border_bevelPos`] = {
+				name: `Supersource ${i + 1} border bevel position`,
+			}
+			variables[`ssrc${i + 1}_border_hue`] = {
+				name: `Supersource ${i + 1} border hue`,
+			}
+			variables[`ssrc${i + 1}_border_sat`] = {
+				name: `Supersource ${i + 1} border saturation`,
+			}
+			variables[`ssrc${i + 1}_border_lum`] = {
+				name: `Supersource ${i + 1} border luma`,
+			}
+			variables[`ssrc${i + 1}_border_lightDirection`] = {
+				name: `Supersource ${i + 1} border light source direction`,
+			}
+			variables[`ssrc${i + 1}_border_lightAltitude`] = {
+				name: `Supersource ${i + 1} border light source altitude`,
+			}
+		}
+
 		updateSuperSourceVariables(instance, state.state, i, values)
 	}
 
@@ -986,7 +1080,7 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 		updateFairlightAudioMonitorVariables(state.state, values)
 	}
 
-	if (model.fairlightAudio?.audioRouting) {
+	if (model.fairlightAudio?.audioRouting && instance.config.enableAudioRoutingVariables) {
 		for (const output of model.fairlightAudio.audioRouting.outputs) {
 			for (const pair of output.channelPairs) {
 				const id = combineInputId(output.outputId, pair)

--- a/src/variables/schema.ts
+++ b/src/variables/schema.ts
@@ -122,6 +122,25 @@ export type VariablesSchema = {
 	[key: `ssrc${number}_box${number}_cropLeft`]: number
 	[key: `ssrc${number}_box${number}_cropRight`]: number
 
+	[key: `ssrc${number}_art_option`]: string | undefined
+	[key: `ssrc${number}_art_preMultiplied`]: boolean | undefined
+	[key: `ssrc${number}_art_clip`]: number | undefined
+	[key: `ssrc${number}_art_gain`]: number | undefined
+	[key: `ssrc${number}_art_invertKey`]: boolean | undefined
+	[key: `ssrc${number}_border_enabled`]: boolean | undefined
+	[key: `ssrc${number}_border_bevel`]: number | undefined
+	[key: `ssrc${number}_border_outWidth`]: number | undefined
+	[key: `ssrc${number}_border_inWidth`]: number | undefined
+	[key: `ssrc${number}_border_outSoft`]: number | undefined
+	[key: `ssrc${number}_border_inSoft`]: number | undefined
+	[key: `ssrc${number}_border_bevelSoft`]: number | undefined
+	[key: `ssrc${number}_border_bevelPos`]: number | undefined
+	[key: `ssrc${number}_border_hue`]: number | undefined
+	[key: `ssrc${number}_border_sat`]: number | undefined
+	[key: `ssrc${number}_border_lum`]: number | undefined
+	[key: `ssrc${number}_border_lightDirection`]: number | undefined
+	[key: `ssrc${number}_border_lightAltitude`]: number | undefined
+
 	[key: `audio_input_${string}_balance`]: string | undefined
 	[key: `audio_input_${string}_faderGain`]: string | undefined
 	[key: `audio_input_${string}_framesDelay`]: string | undefined


### PR DESCRIPTION
## What
Adds new variables exposing SuperSource art and border properties that were previously only available as actions/feedbacks, not as variables:

- **Art**: `ssrc{n}_art_option` (foreground/background placement), `_art_preMultiplied`, `_art_clip`, `_art_gain`, `_art_invertKey`.
- **Border**: `ssrc{n}_border_enabled`, `_bevel`, `_outWidth`, `_inWidth`, `_outSoft`, `_inSoft`, `_bevelSoft`, `_bevelPos`, `_hue`, `_sat`, `_lum`, `_lightDirection`, `_lightAltitude`.

These use the same scaling conventions as the existing SuperSource actions/feedbacks (`/10` for hue/sat/luma/clip/gain/light direction, `/100` for widths, raw for softness/bevel/enable).

Also fixed a pre-existing gap in change-detection: `video.superSources.N.border` updates were not tracked (only `.properties`/`.boxes` were), so these new border variables would not have updated live without it.

## Config toggles
Since this and the existing USK/audio-routing variables add up to a lot of new variables, three config options (all default **off**) were added so users can opt in to only what they need, keeping the default variable list manageable:

- **Enable advanced SuperSource variables** — the new art/border variables described above.
- **Enable advanced USK variables** — gates the existing detailed USK DVE mask/border settings, pattern settings, luma settings, and advanced chroma settings. Core USK variables (`input`, `input_id`, `onAir`, `positionX/Y`, `sizeX/Y`, `rotation`, `rate`, `canFlyKey`, `flyEnabled`) remain always available and unaffected.
- **Enable audio routing variables** — gates the existing Fairlight audio routing source/destination variables (`audio_routing_destinations_*`, `audio_routing_source_*`).

Toggling any of these triggers the existing `configUpdated` flow, which re-runs `InitVariables` and rebuilds the variable definitions accordingly — no restart needed.

## Testing
- `tsc -p tsconfig.build.json` — clean
- `yarn vitest run` — 238/238 passing