### PR TITLE
fix: clamp Fairlight master gain adjustments

### DIFF
--- a/src/actions/fairlightAudio.ts
+++ b/src/actions/fairlightAudio.ts
@@ -22,6 +22,7 @@ import {
 	parseAudioRoutingStringSingle,
 } from '../options/fairlight-routing.js'
 import { FadeDurationFields } from '../options/fade.js'
+import { clamp } from '../util.js'
 
 export type AtemFairlightAudioActions = {
 	['fairlightAudioInputGain']: {
@@ -781,7 +782,7 @@ export function createFairlightAudioActions(
 							})
 						},
 						currentGain,
-						currentGain + options.delta * 100,
+						clamp(-10000, 600, currentGain + options.delta * 100),
 						options,
 					)
 				}


### PR DESCRIPTION
Fixes #486.

Fairlight master gain has a documented range of -100 to +6 dB. The absolute set action already enforces it, but the relative Adjust action could compute an out-of-range target, such as +6 plus +4 dB.

Clamp the relative target to the same -100 to +6 dB range before it is sent to the ATEM. This preserves the valid input/source range separately and prevents an invalid master-fader command.

Validation: build and lint pass; focused action test confirms +6 dB plus +4 dB sends +6 dB.