### PR TITLE
fix: expose common USK mask variables and clarify DVE labels

### DIFF
--- a/src/variables/__tests__/upstreamKeyerMask.test.ts
+++ b/src/variables/__tests__/upstreamKeyerMask.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'vitest'
+import { AtemStateUtil, Enums } from 'atem-connection'
+import { InitVariables, updateChangedVariables, type UpdateVariablesProps } from '../lib.js'
+import { ALL_MODELS } from '../../models/index.js'
+import { makeTestState } from '../../__tests__/helpers.js'
+import type { InstanceBaseExt } from '../../util.js'
+
+const MODEL = { ...ALL_MODELS.find((model) => model.USKs && model.DVEs)!, MEs: 2, USKs: 2 }
+
+function fixture() {
+	const state = makeTestState()
+	const definitions: Record<string, { name: string }> = {}
+	const values: Record<string, unknown> = {}
+	const instance = {
+		config: {},
+		parseIpAndPort: () => undefined,
+		setVariableDefinitions: (next: typeof definitions) => Object.assign(definitions, next),
+		setVariableValues: (next: typeof values) => Object.assign(values, next),
+	} as unknown as InstanceBaseExt
+	return { state, definitions, values, instance }
+}
+
+function changesFor(me: number, key: number): UpdateVariablesProps {
+	return {
+		meProgram: new Set(),
+		mePreview: new Set(),
+		transitionPosition: new Set(),
+		transitionRate: new Set(),
+		auxes: new Set(),
+		dsk: new Set(),
+		usk: new Set([[me, key]]),
+		macros: new Set(),
+		ssrc: new Set(),
+		mediaPlayer: new Set(),
+		streaming: false,
+		recording: false,
+		classicAudio: new Set(),
+		fairlightAudio: new Set(),
+		fairlightAudioMaster: false,
+		fairlightAudioMonitor: false,
+		fairlightRoutingSources: new Set(),
+		fairlightRoutingOutputs: new Set(),
+		mvWindow: new Set(),
+	}
+}
+
+describe('USK mask variables (#491)', () => {
+	test('labels the existing DVE variables explicitly without renaming their IDs', () => {
+		const f = fixture()
+		InitVariables(f.instance, MODEL, f.state)
+		expect(f.definitions.usk_2_2_maskEnabled?.name).toBe('DVE Mask Enabled for M/E 2 Key 2')
+		for (const side of ['Top', 'Bottom', 'Left', 'Right']) {
+			expect(f.definitions[`usk_2_2_mask${side}`]?.name).toContain('DVE Mask')
+		}
+		expect(f.definitions.usk_2_2_bordLum?.name).toBe('Border Luminance of M/E 2 Key 2')
+	})
+
+	test('defines non-DVE mask variables even on a model without DVEs', () => {
+		const f = fixture()
+		InitVariables(f.instance, { ...MODEL, DVEs: 0 }, f.state)
+		expect(f.definitions.usk_2_2_nonDVEmaskEnabled?.name).toBe('Luma-Chroma-Pattern Mask Enabled for M/E 2 Key 2')
+		for (const suffix of ['Enabled', 'Top', 'Bottom', 'Left', 'Right']) {
+			expect(f.definitions[`usk_2_2_nonDVEmask${suffix}`]).toBeDefined()
+		}
+		expect(f.definitions.usk_2_2_maskEnabled).toBeUndefined()
+	})
+
+	test.each([Enums.MixEffectKeyType.Luma, Enums.MixEffectKeyType.Chroma, Enums.MixEffectKeyType.Pattern])(
+		'initializes common mask values independently from DVE settings for key type %s',
+		(keyType) => {
+			const f = fixture()
+			const me = AtemStateUtil.getMixEffect(f.state.state, 1)
+			me.upstreamKeyers[1] = {
+				mixEffectKeyType: keyType,
+				maskSettings: { maskEnabled: true, maskTop: 1250, maskBottom: -2500, maskLeft: -3500, maskRight: 4500 },
+				dveSettings: {
+					maskEnabled: false,
+					maskTop: 8000,
+					maskBottom: -8000,
+					maskLeft: -12000,
+					maskRight: 12000,
+					borderLuma: 750,
+				},
+			} as any
+			InitVariables(f.instance, MODEL, f.state)
+			expect(f.values).toMatchObject({
+				usk_2_2_nonDVEmaskEnabled: true,
+				usk_2_2_nonDVEmaskTop: 1.25,
+				usk_2_2_nonDVEmaskBottom: -2.5,
+				usk_2_2_nonDVEmaskLeft: -3.5,
+				usk_2_2_nonDVEmaskRight: 4.5,
+				usk_2_2_maskEnabled: false,
+				usk_2_2_maskTop: 8,
+				usk_2_2_maskBottom: -8,
+				usk_2_2_maskLeft: -12,
+				usk_2_2_maskRight: 12,
+				usk_2_2_bordLum: 75,
+			})
+		},
+	)
+
+	test('refreshes common mask values through the normal change handler, including false and zero', () => {
+		const f = fixture()
+		const me = AtemStateUtil.getMixEffect(f.state.state, 0)
+		me.upstreamKeyers[0] = {
+			maskSettings: { maskEnabled: true, maskTop: 1000, maskBottom: -1000, maskLeft: -2000, maskRight: 2000 },
+		} as any
+		InitVariables(f.instance, MODEL, f.state)
+		me.upstreamKeyers[0]!.maskSettings = { maskEnabled: false, maskTop: 0, maskBottom: 0, maskLeft: 0, maskRight: 0 }
+		updateChangedVariables(f.instance, f.state.state, changesFor(0, 0))
+		expect(f.values).toMatchObject({
+			usk_1_1_nonDVEmaskEnabled: false,
+			usk_1_1_nonDVEmaskTop: 0,
+			usk_1_1_nonDVEmaskBottom: 0,
+			usk_1_1_nonDVEmaskLeft: 0,
+			usk_1_1_nonDVEmaskRight: 0,
+		})
+	})
+
+	test('clears previously observed common mask values when key state is no longer available', () => {
+		const f = fixture()
+		const me = AtemStateUtil.getMixEffect(f.state.state, 0)
+		me.upstreamKeyers[0] = {
+			maskSettings: { maskEnabled: true, maskTop: 1000, maskBottom: -1000, maskLeft: -2000, maskRight: 2000 },
+		} as any
+		InitVariables(f.instance, MODEL, f.state)
+		expect(f.values.usk_1_1_nonDVEmaskEnabled).toBe(true)
+		me.upstreamKeyers.splice(0)
+		updateChangedVariables(f.instance, f.state.state, changesFor(0, 0))
+		for (const suffix of ['Enabled', 'Top', 'Bottom', 'Left', 'Right']) {
+			expect(f.values[`usk_1_1_nonDVEmask${suffix}`]).toBeUndefined()
+		}
+	})
+})

--- a/src/variables/lib.ts
+++ b/src/variables/lib.ts
@@ -173,6 +173,12 @@ function updateUSKVariable(
 	values[`usk_${meIndex + 1}_${keyIndex + 1}_input`] = getSourcePresetName(instance, state, input)
 	values[`usk_${meIndex + 1}_${keyIndex + 1}_input_id`] = input
 	values[`pgm${meIndex + 1}_usk_${keyIndex + 1}_onAir`] = !!getUSK(state, meIndex, keyIndex)?.onAir
+	const mask = getUSK(state, meIndex, keyIndex)?.maskSettings
+	values[`usk_${meIndex + 1}_${keyIndex + 1}_nonDVEmaskEnabled`] = mask?.maskEnabled
+	values[`usk_${meIndex + 1}_${keyIndex + 1}_nonDVEmaskTop`] = mask ? mask.maskTop / 1000 : undefined
+	values[`usk_${meIndex + 1}_${keyIndex + 1}_nonDVEmaskBottom`] = mask ? mask.maskBottom / 1000 : undefined
+	values[`usk_${meIndex + 1}_${keyIndex + 1}_nonDVEmaskLeft`] = mask ? mask.maskLeft / 1000 : undefined
+	values[`usk_${meIndex + 1}_${keyIndex + 1}_nonDVEmaskRight`] = mask ? mask.maskRight / 1000 : undefined
 	const dveSettings = state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]?.dveSettings
 	if (dveSettings) {
 		values[`usk_${meIndex + 1}_${keyIndex + 1}_maskEnabled`] = dveSettings.maskEnabled
@@ -565,21 +571,36 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 			variables[`pgm${i + 1}_usk_${k + 1}_onAir`] = {
 				name: `On Air state of M/E ${i + 1} Key ${k + 1}`,
 			}
+			variables[`usk_${i + 1}_${k + 1}_nonDVEmaskEnabled`] = {
+				name: `Luma-Chroma-Pattern Mask Enabled for M/E ${i + 1} Key ${k + 1}`,
+			}
+			variables[`usk_${i + 1}_${k + 1}_nonDVEmaskTop`] = {
+				name: `Luma-Chroma-Pattern Mask cutoff from the top of M/E ${i + 1} Key ${k + 1}`,
+			}
+			variables[`usk_${i + 1}_${k + 1}_nonDVEmaskBottom`] = {
+				name: `Luma-Chroma-Pattern Mask cutoff from the bottom of M/E ${i + 1} Key ${k + 1}`,
+			}
+			variables[`usk_${i + 1}_${k + 1}_nonDVEmaskLeft`] = {
+				name: `Luma-Chroma-Pattern Mask cutoff from the left of M/E ${i + 1} Key ${k + 1}`,
+			}
+			variables[`usk_${i + 1}_${k + 1}_nonDVEmaskRight`] = {
+				name: `Luma-Chroma-Pattern Mask cutoff from the right of M/E ${i + 1} Key ${k + 1}`,
+			}
 			if (model.USKs && model.DVEs) {
 				variables[`usk_${i + 1}_${k + 1}_maskEnabled`] = {
-					name: `Mask Enabled for M/E ${i + 1} Key ${k + 1}`,
+					name: `DVE Mask Enabled for M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_maskTop`] = {
-					name: `Mask cutoff from the top of M/E ${i + 1} Key ${k + 1}`,
+					name: `DVE Mask cutoff from the top of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_maskBottom`] = {
-					name: `Mask cutoff from the bottom of M/E ${i + 1} Key ${k + 1}`,
+					name: `DVE Mask cutoff from the bottom of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_maskLeft`] = {
-					name: `Mask cutoff from the left of M/E ${i + 1} Key ${k + 1}`,
+					name: `DVE Mask cutoff from the left of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_maskRight`] = {
-					name: `Mask cutoff from the right of M/E ${i + 1} Key ${k + 1}`,
+					name: `DVE Mask cutoff from the right of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_positionX`] = {
 					name: `X position of M/E ${i + 1} Key ${k + 1}`,
@@ -624,7 +645,7 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 					name: `Border Saturation of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_bordLum`] = {
-					name: `Border Luma of M/E ${i + 1} Key ${k + 1}`,
+					name: `Border Luminance of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_lightDirection`] = {
 					name: `Light source Angle of shadow of M/E ${i + 1} Key ${k + 1}`,

--- a/src/variables/schema.ts
+++ b/src/variables/schema.ts
@@ -16,6 +16,11 @@ export type VariablesSchema = {
 
 	[key: `usk_${number}_${number}_input`]: string
 	[key: `usk_${number}_${number}_input_id`]: number
+	[key: `usk_${number}_${number}_nonDVEmaskEnabled`]: boolean | undefined
+	[key: `usk_${number}_${number}_nonDVEmaskTop`]: number | undefined
+	[key: `usk_${number}_${number}_nonDVEmaskBottom`]: number | undefined
+	[key: `usk_${number}_${number}_nonDVEmaskLeft`]: number | undefined
+	[key: `usk_${number}_${number}_nonDVEmaskRight`]: number | undefined
 	[key: `usk_${number}_${number}_maskEnabled`]: boolean | undefined
 	[key: `usk_${number}_${number}_maskTop`]: number | undefined
 	[key: `usk_${number}_${number}_maskBottom`]: number | undefined


### PR DESCRIPTION
## Summary

Fixes #491.

- Clarify the existing `usk_*_maskEnabled/Top/Bottom/Left/Right` descriptions as **DVE Mask**, keeping their IDs and values unchanged.
- Change the `bordLum` description to **Border Luminance**, without renaming the variable or changing its units.
- Add `usk_<ME>_<key>_nonDVEmaskEnabled/Top/Bottom/Left/Right` from the existing upstream-keyer `maskSettings` state, separate from `dveSettings`. These variables are available for USKs even on models without a DVE.
- Use the same /1000 mask coordinate conversion as the existing common-mask action. Populate on initialization and through the existing USK change handler; publish undefined if the common mask state is unavailable rather than retaining an old value.

No new protocol commands, polling or hardware-control behavior. Existing variable IDs are preserved, so existing buttons/expressions do not need migration. This branch is independent of #492.

## Validation

- Seven new tests reproduce the issue before the fix and pass afterward: labels/IDs, non-DVE models, separate common/DVE state for Luma/Chroma/Pattern, multiple ME/key indices, false/zero updates, and missing-state clearing.
- Full test suite: 291 tests pass in 29 files.
- Production TypeScript build, changed-file ESLint/Prettier, `git diff --check` and `companion-module-check` pass locally.
- Additional whole-project type check with `--rootDir .` still reports the existing errors in `src/actions/__tests__/inputPorts.test.ts`; no new test errors. That unrelated file is unchanged.

Tested with local state fixtures, not a physical switcher. Hardware confirmation of the new variables is welcome.
