### PR TITLE
fix: upload external multiview labels after renaming

### DIFF
--- a/src/actions/__tests__/settings.test.ts
+++ b/src/actions/__tests__/settings.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest'
+import type { Atem } from 'atem-connection'
+
+import { createSettingsActions } from '../settings.js'
+import { ALL_MODELS } from '../../models/index.js'
+import { makeTestState } from '../../__tests__/helpers.js'
+
+const MODEL = ALL_MODELS.find((model) => model.media.players > 0)!
+type ActionDefinition = { callback: (info: any) => Promise<void> }
+
+function makeAtem(internalLabels: boolean) {
+	const calls: string[] = []
+	const atem = {
+		hasInternalMultiviewerLabelGeneration: () => internalLabels,
+		setInputSettings: async () => {
+			calls.push('setInputSettings')
+		},
+		drawMultiviewerLabel: async () => {
+			calls.push('drawMultiviewerLabel')
+		},
+	} as unknown as Atem
+	return { atem, calls }
+}
+
+describe('input name and multiview label ordering (#449)', () => {
+	test('uploads an external UMD label only after changing the input name', async () => {
+		const mock = makeAtem(false)
+		const actions = createSettingsActions(mock.atem, MODEL, makeTestState())
+		const action = actions.inputName as unknown as ActionDefinition
+
+		await action.callback({
+			options: {
+				source: 3,
+				short_enable: true,
+				short_value: 'CAM3',
+				long_enable: true,
+				long_value: 'Camera 3',
+			},
+		})
+
+		expect(mock.calls).toEqual(['setInputSettings', 'drawMultiviewerLabel'])
+	})
+
+	test('does not upload a bitmap on models that render labels internally', async () => {
+		const mock = makeAtem(true)
+		const actions = createSettingsActions(mock.atem, MODEL, makeTestState())
+		const action = actions.inputName as unknown as ActionDefinition
+
+		await action.callback({
+			options: {
+				source: 3,
+				short_enable: false,
+				short_value: '',
+				long_enable: true,
+				long_value: 'Camera 3',
+			},
+		})
+
+		expect(mock.calls).toEqual(['setInputSettings'])
+	})
+})

--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -94,12 +94,14 @@ export function createSettingsActions(
 				if (setShort) newProps.shortName = options.short_value
 				if (setLong) newProps.longName = options.long_value
 
-				await Promise.all([
-					typeof newProps.longName === 'string' && !atem?.hasInternalMultiviewerLabelGeneration()
-						? atem?.drawMultiviewerLabel(source, newProps.longName)
-						: undefined,
-					Object.keys(newProps).length ? atem?.setInputSettings(newProps, source) : undefined,
-				])
+				if (Object.keys(newProps).length) await atem?.setInputSettings(newProps, source)
+
+				// Older ATEMs need a separately uploaded UMD bitmap. Upload it only
+				// after the name command, so firmware that redraws the UMD while applying
+				// the name cannot overwrite the correctly generated label.
+				if (typeof newProps.longName === 'string' && atem && !atem.hasInternalMultiviewerLabelGeneration()) {
+					await atem.drawMultiviewerLabel(source, newProps.longName)
+				}
 			},
 			learn: ({ options }) => {
 				const source = parseSourceId(options.source)


### PR DESCRIPTION
## Summary

For ATEMs without internal multiview-label generation (notably Constellation 8K), `Input: Set name` currently starts the input-name command and the separately generated UMD bitmap upload concurrently.

Firmware 10.2 can redraw the UMD while applying the name. If that command completes after the external bitmap upload, its malformed/default rendering overwrites the correct label. This matches #449: the name is stored, the multiview label becomes oversized/cropped, and a subsequent rename in ATEM Software Control restores it.

Send the input-name update first, then upload the generated multiview label. Models with internal label generation remain unchanged and receive only the name command.

Closes #449.

## Evidence and verification

- inspected both state captures attached to #449: each contains 3,800 ATEM state commands and the expected `InPr` name differences; UMD bitmap transfers are not represented in these state snapshots
- regression test proves external-label models call `setInputSettings` before `drawMultiviewerLabel`
- regression test proves internal-label models do not receive a bitmap upload
- full suite: 286 tests pass
- TypeScript, targeted ESLint/Prettier and module package build pass

Hardware validation is still requested on Constellation 8K firmware 10.2; the PR does not claim that the state captures alone prove the transfer race.
