### PR TITLE
fix: support +10 dB Fairlight master gain

### DIFF
--- a/src/actions/__tests__/fairlightAudio.test.ts
+++ b/src/actions/__tests__/fairlightAudio.test.ts
@@ -87,3 +87,40 @@ describe('Fairlight source validation (#356)', () => {
 		expect(mock.calls).toHaveLength(0)
 	})
 })
+
+describe('Fairlight master gain range (#486)', () => {
+	let mock: ReturnType<typeof makeMockAtem>
+	let state: ReturnType<typeof makeTestState>
+	let transitions: AtemTransitions
+
+	beforeEach(() => {
+		mock = makeMockAtem()
+		state = makeTestState()
+		transitions = new AtemTransitions({ fadeFps: 10 })
+		state.state.fairlight = {
+			master: { properties: { faderGain: 900 } },
+			inputs: {},
+		} as any
+	})
+
+	function actions() {
+		return createFairlightAudioActions(mock.atem, MODEL, transitions, state)
+	}
+
+	test('set action exposes the hardware-confirmed +10 dB maximum', () => {
+		const definition = actions().fairlightAudioMasterGain as any
+		const gain = definition.options.find((option: { id: string }) => option.id === 'gain')
+
+		expect(gain.max).toBe(10)
+	})
+
+	test('relative adjustment sends +10 dB but never exceeds it', async () => {
+		const definition = actions().fairlightAudioMasterGainDelta as unknown as AnyDef
+
+		await definition.callback({
+			options: { delta: 5, fadeDuration: 0, fadeAlgorithm: 'linear', fadeCurve: 'in' },
+		})
+
+		expect(mock.onlyCall('setFairlightAudioMixerMasterProps').args[0]).toEqual({ faderGain: 1000 })
+	})
+})

--- a/src/actions/fairlightAudio.ts
+++ b/src/actions/fairlightAudio.ts
@@ -22,6 +22,10 @@ import {
 	parseAudioRoutingStringSingle,
 } from '../options/fairlight-routing.js'
 import { FadeDurationFields } from '../options/fade.js'
+import { clamp } from '../util.js'
+
+const FAIRLIGHT_MASTER_MIN_GAIN = -10000
+const FAIRLIGHT_MASTER_MAX_GAIN = 1000
 
 export type AtemFairlightAudioActions = {
 	['fairlightAudioInputGain']: {
@@ -730,7 +734,7 @@ export function createFairlightAudioActions(
 					default: 0,
 					step: 0.1,
 					min: -100,
-					max: 6,
+					max: FAIRLIGHT_MASTER_MAX_GAIN / 100,
 					description: '-100 = -inf',
 					showMinAsNegativeInfinity: true,
 					asInteger: false,
@@ -781,7 +785,7 @@ export function createFairlightAudioActions(
 							})
 						},
 						currentGain,
-						currentGain + options.delta * 100,
+						clamp(FAIRLIGHT_MASTER_MIN_GAIN, FAIRLIGHT_MASTER_MAX_GAIN, currentGain + options.delta * 100),
 						options,
 					)
 				}


### PR DESCRIPTION
## Summary

Correct the Fairlight master-fader range from +6 dB to the hardware-confirmed +10 dB, and clamp relative adjustments to the same protocol range before sending them.

The feedback already exposes +10 dB, as do Fairlight source and monitor/headphone faders. This aligns the master Set action and Adjust action with that existing behaviour.

Closes #486.

## Evidence

- maintainer checked several models and found +10 dB to be the correct maximum
- reporter provided an ATEM SDI Extreme screenshot showing the master fader at +10 dB
- the previous +6-clamp proposal (#490) remains closed and is not reused

## Verification

- regression test confirms the Set action exposes +10 dB
- regression test starts at +9 dB, applies +5 dB and confirms exactly +10 dB (`1000`) is sent
- full suite: 286 tests pass
- TypeScript build, targeted ESLint/Prettier, package build and `git diff --check` pass

No physical command was sent by this change. A final hardware check is requested for Set +10 and Adjust at the upper boundary.