### PR TITLE
fix: distinguish multiple XLR audio inputs

### DIFF
--- a/src/options/__tests__/audio.test.ts
+++ b/src/options/__tests__/audio.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest'
+import type { AtemState } from 'atem-connection'
+import { ModelSpecMiniExtremeISOG2 } from '../../models/miniextremeisog2.js'
+import { ModelSpecTVSHD8 } from '../../models/tvshd8.js'
+import { GetAudioInputsList } from '../audio.js'
+
+const state = { inputs: {} } as AtemState
+
+describe('GetAudioInputsList', () => {
+	test('numbers both XLR inputs when a model has more than one', () => {
+		const inputs = GetAudioInputsList(ModelSpecMiniExtremeISOG2, state)
+
+		expect(inputs.filter(({ id }) => id === 1001 || id === 1002)).toEqual([
+			{ id: 1001, longName: 'XLR 1' },
+			{ id: 1002, longName: 'XLR 2' },
+		])
+	})
+
+	test('keeps the unnumbered label for models with one XLR input', () => {
+		const inputs = GetAudioInputsList(ModelSpecTVSHD8, state)
+
+		expect(inputs.find(({ id }) => id === 1001)).toEqual({ id: 1001, longName: 'XLR' })
+	})
+})

--- a/src/options/audio.ts
+++ b/src/options/audio.ts
@@ -175,6 +175,9 @@ export const CHOICES_CLASSIC_AUDIO_MIX_OPTION: DropdownChoice<Enums.AudioMixOpti
 export type AudioInputSubset = 'delay' | 'routing'
 
 export function GetAudioInputsList(model: ModelSpec, state: AtemState, subset?: AudioInputSubset): MiniSourceInfo[] {
+	const audioInputs = model.classicAudio?.inputs ?? model.fairlightAudio?.inputs ?? []
+	const xlrInputCount = audioInputs.filter((input) => input.portType === Enums.ExternalPortType.XLR).length
+
 	const getSource = (id: number, videoId: number | undefined, defLong: string): MiniSourceInfo => {
 		const input = videoId !== undefined ? state.inputs[videoId] : undefined
 		const longName = input?.longName || defLong
@@ -186,7 +189,7 @@ export function GetAudioInputsList(model: ModelSpec, state: AtemState, subset?: 
 	}
 
 	const sources: MiniSourceInfo[] = []
-	for (const input of model.classicAudio?.inputs ?? model.fairlightAudio?.inputs ?? []) {
+	for (const input of audioInputs) {
 		if (subset === 'delay' && (!('maxDelay' in input) || !input.maxDelay)) continue
 		if (subset !== 'routing' && 'routingOnly' in input && input.routingOnly) continue
 
@@ -203,7 +206,7 @@ export function GetAudioInputsList(model: ModelSpec, state: AtemState, subset?: 
 				break
 			case Enums.ExternalPortType.XLR: {
 				const offset = input.id - 1000
-				sources.push(getSource(input.id, undefined, offset > 1 ? `XLR ${offset}` : `XLR`))
+				sources.push(getSource(input.id, undefined, xlrInputCount > 1 ? `XLR ${offset}` : `XLR`))
 				break
 			}
 			case Enums.ExternalPortType.AESEBU:


### PR DESCRIPTION
Fixes the confirmed labeling part of #425.

The Mini Extreme ISO G2 has two Fairlight XLR inputs, but the picker currently labels them `XLR` and `XLR 2`. This changes multi-XLR models to show `XLR 1`, `XLR 2`, while preserving the existing unnumbered `XLR` label for models that expose only one XLR input.

I also inspected the recorded firmware 10.1.1 startup capture in `sofie-atem-connection`: the switcher advertises XLR input IDs `1001` and `1002`, each with the mono source ID `-256`. Media players `2001`/`2002` and Thunderbolt `2051` advertise the stereo source ID `-65280`. Those IDs already match the current module, so this PR intentionally does not change command routing without evidence of a remaining failure on a current module build.

Tests added for both the dual-XLR and single-XLR cases.

Validation:
- `yarn test`: 29 files, 286 tests passed
- `yarn lint`: passed
- `yarn build`: passed
- Prettier check: passed