### PR TITLE
fix: expose distinct USK mask variables

### DIFF
--- a/src/variables/__tests__/upstreamKeyerMask.test.ts
+++ b/src/variables/__tests__/upstreamKeyerMask.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest'
+import { AtemStateUtil } from 'atem-connection'
+import type { InstanceBaseExt } from '../../util.js'
+import { updateUSKVariable } from '../lib.js'
+import type { VariablesSchema } from '../schema.js'
+
+const INSTANCE = { config: {} } as unknown as InstanceBaseExt
+
+describe('USK mask variables (#491)', () => {
+	test('keeps the Luma/Chroma/Pattern mask separate from the DVE mask', () => {
+		const state = AtemStateUtil.Create()
+		state.video.mixEffects[0] = {
+			upstreamKeyers: [
+				{
+					fillSource: 0,
+					onAir: false,
+					maskSettings: {
+						maskEnabled: true,
+						maskTop: 9000,
+						maskBottom: -9000,
+						maskLeft: -16000,
+						maskRight: 16000,
+					},
+					dveSettings: {
+						maskEnabled: false,
+						maskTop: 1000,
+						maskBottom: -1000,
+						maskLeft: -2000,
+						maskRight: 2000,
+					},
+				} as never,
+			],
+		} as never
+
+		const values: Partial<VariablesSchema> = {}
+		updateUSKVariable(INSTANCE, state, 0, 0, values)
+
+		expect(values['usk_1_1_nonDVEmaskEnabled']).toBe(true)
+		expect(values['usk_1_1_nonDVEmaskTop']).toBe(9)
+		expect(values['usk_1_1_nonDVEmaskBottom']).toBe(-9)
+		expect(values['usk_1_1_nonDVEmaskLeft']).toBe(-16)
+		expect(values['usk_1_1_nonDVEmaskRight']).toBe(16)
+		expect(values['usk_1_1_maskEnabled']).toBe(false)
+	})
+})

--- a/src/variables/lib.ts
+++ b/src/variables/lib.ts
@@ -162,7 +162,7 @@ export function updateMETransitionRateVariables(
 	}
 }
 
-function updateUSKVariable(
+export function updateUSKVariable(
 	instance: InstanceBaseExt,
 	state: AtemState,
 	meIndex: number,
@@ -173,6 +173,14 @@ function updateUSKVariable(
 	values[`usk_${meIndex + 1}_${keyIndex + 1}_input`] = getSourcePresetName(instance, state, input)
 	values[`usk_${meIndex + 1}_${keyIndex + 1}_input_id`] = input
 	values[`pgm${meIndex + 1}_usk_${keyIndex + 1}_onAir`] = !!getUSK(state, meIndex, keyIndex)?.onAir
+	const maskSettings = state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]?.maskSettings
+	if (maskSettings) {
+		values[`usk_${meIndex + 1}_${keyIndex + 1}_nonDVEmaskEnabled`] = maskSettings.maskEnabled
+		values[`usk_${meIndex + 1}_${keyIndex + 1}_nonDVEmaskTop`] = maskSettings.maskTop / 1000
+		values[`usk_${meIndex + 1}_${keyIndex + 1}_nonDVEmaskBottom`] = maskSettings.maskBottom / 1000
+		values[`usk_${meIndex + 1}_${keyIndex + 1}_nonDVEmaskLeft`] = maskSettings.maskLeft / 1000
+		values[`usk_${meIndex + 1}_${keyIndex + 1}_nonDVEmaskRight`] = maskSettings.maskRight / 1000
+	}
 	const dveSettings = state.video.mixEffects[meIndex]?.upstreamKeyers[keyIndex]?.dveSettings
 	if (dveSettings) {
 		values[`usk_${meIndex + 1}_${keyIndex + 1}_maskEnabled`] = dveSettings.maskEnabled
@@ -565,21 +573,36 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 			variables[`pgm${i + 1}_usk_${k + 1}_onAir`] = {
 				name: `On Air state of M/E ${i + 1} Key ${k + 1}`,
 			}
+			variables[`usk_${i + 1}_${k + 1}_nonDVEmaskEnabled`] = {
+				name: `Luma/Chroma/Pattern Mask Enabled for M/E ${i + 1} Key ${k + 1}`,
+			}
+			variables[`usk_${i + 1}_${k + 1}_nonDVEmaskTop`] = {
+				name: `Luma/Chroma/Pattern Mask cutoff from the top of M/E ${i + 1} Key ${k + 1}`,
+			}
+			variables[`usk_${i + 1}_${k + 1}_nonDVEmaskBottom`] = {
+				name: `Luma/Chroma/Pattern Mask cutoff from the bottom of M/E ${i + 1} Key ${k + 1}`,
+			}
+			variables[`usk_${i + 1}_${k + 1}_nonDVEmaskLeft`] = {
+				name: `Luma/Chroma/Pattern Mask cutoff from the left of M/E ${i + 1} Key ${k + 1}`,
+			}
+			variables[`usk_${i + 1}_${k + 1}_nonDVEmaskRight`] = {
+				name: `Luma/Chroma/Pattern Mask cutoff from the right of M/E ${i + 1} Key ${k + 1}`,
+			}
 			if (model.USKs && model.DVEs) {
 				variables[`usk_${i + 1}_${k + 1}_maskEnabled`] = {
-					name: `Mask Enabled for M/E ${i + 1} Key ${k + 1}`,
+					name: `DVE Mask Enabled for M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_maskTop`] = {
-					name: `Mask cutoff from the top of M/E ${i + 1} Key ${k + 1}`,
+					name: `DVE Mask cutoff from the top of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_maskBottom`] = {
-					name: `Mask cutoff from the bottom of M/E ${i + 1} Key ${k + 1}`,
+					name: `DVE Mask cutoff from the bottom of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_maskLeft`] = {
-					name: `Mask cutoff from the left of M/E ${i + 1} Key ${k + 1}`,
+					name: `DVE Mask cutoff from the left of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_maskRight`] = {
-					name: `Mask cutoff from the right of M/E ${i + 1} Key ${k + 1}`,
+					name: `DVE Mask cutoff from the right of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_positionX`] = {
 					name: `X position of M/E ${i + 1} Key ${k + 1}`,
@@ -624,7 +647,7 @@ export function InitVariables(instance: InstanceBaseExt, model: ModelSpec, state
 					name: `Border Saturation of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_bordLum`] = {
-					name: `Border Luma of M/E ${i + 1} Key ${k + 1}`,
+					name: `Border Luminance of M/E ${i + 1} Key ${k + 1}`,
 				}
 				variables[`usk_${i + 1}_${k + 1}_lightDirection`] = {
 					name: `Light source Angle of shadow of M/E ${i + 1} Key ${k + 1}`,

--- a/src/variables/schema.ts
+++ b/src/variables/schema.ts
@@ -16,6 +16,11 @@ export type VariablesSchema = {
 
 	[key: `usk_${number}_${number}_input`]: string
 	[key: `usk_${number}_${number}_input_id`]: number
+	[key: `usk_${number}_${number}_nonDVEmaskEnabled`]: boolean | undefined
+	[key: `usk_${number}_${number}_nonDVEmaskTop`]: number | undefined
+	[key: `usk_${number}_${number}_nonDVEmaskBottom`]: number | undefined
+	[key: `usk_${number}_${number}_nonDVEmaskLeft`]: number | undefined
+	[key: `usk_${number}_${number}_nonDVEmaskRight`]: number | undefined
 	[key: `usk_${number}_${number}_maskEnabled`]: boolean | undefined
 	[key: `usk_${number}_${number}_maskTop`]: number | undefined
 	[key: `usk_${number}_${number}_maskBottom`]: number | undefined


### PR DESCRIPTION
Fixes #483.
Fixes #491.

ATEM exposes two different upstream-key mask groups:

- the common mask used by Luma, Chroma and Pattern keyers (`maskSettings`);
- the separate DVE mask (`dveSettings`).

The module currently publishes only the DVE values under generic mask descriptions, so the common mask cannot be shown on Companion and the existing variables are easy to misinterpret.

This change:

- adds `nonDVEmaskEnabled`, `nonDVEmaskTop`, `nonDVEmaskBottom`, `nonDVEmaskLeft` and `nonDVEmaskRight` for the common mask;
- preserves every existing variable ID for compatibility;
- labels the existing mask variables explicitly as DVE mask state;
- corrects `Border Luma` to `Border Luminance`;
- adds a regression test proving that common and DVE mask states remain distinct and that mask units match the action fields.

This is read-only state exposure; no ATEM command changes.

Checks: full suite 285/285, TypeScript build, ESLint, formatting, module check, and package build all pass.

Signed test package: https://github.com/iibaranov-IG/companion-module-bmd-atem/releases/tag/pr499-test-5a5bbec
